### PR TITLE
Feature/add type to filter struct and publishing checks

### DIFF
--- a/api/filters.go
+++ b/api/filters.go
@@ -15,6 +15,10 @@ import (
 	"github.com/pkg/errors"
 )
 
+const (
+	flexible = "flexible"
+)
+
 func (api *API) createFilter(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	var req createFilterRequest
@@ -93,6 +97,7 @@ func (api *API) createFilter(w http.ResponseWriter, r *http.Request) {
 		LastUpdated:       api.generate.Timestamp(),
 		Dataset:           *req.Dataset,
 		PopulationType:    req.PopulationType,
+		Type:              flexible,
 		Published:         true, // TODO: Not sure what to
 		Events:            nil,  // populate for these
 		DisclosureControl: nil,  // fields yet

--- a/features/filters.authorized.feature
+++ b/features/filters.authorized.feature
@@ -110,7 +110,7 @@ Feature: Filters Private Endpoints Enabled
       "events": null,
       "unique_timestamp": "2022-01-26T12:27:04.783936865Z",
       "last_updated":     "2022-01-26T12:27:04.783936865Z",
-      "etag":             "63d6683de011a71313bc4918b5e610c4099a7d49",
+      "etag":             "6e627be2c355c7cebe5de4af6a0c6d75c9523fb3",
       "instance_id":      "c733977d-a2ca-4596-9cb1-08a6e724858b",
       "dimensions": [
         {
@@ -140,7 +140,8 @@ Feature: Filters Private Endpoints Enabled
         "version": 1
       },
       "published":       true,
-      "population_type": "Example"
+      "population_type": "Example",
+      "type": "flexible"
     }
     """
 
@@ -162,7 +163,7 @@ Feature: Filters Private Endpoints Enabled
       "events": null,
       "unique_timestamp": "2022-01-26T12:27:04.783936865Z",
       "last_updated":     "2022-01-26T12:27:04.783936865Z",
-      "etag":             "79a0377838c36642bce63f3d2d9addf6e47dbaa0",
+      "etag":             "6e627be2c355c7cebe5de4af6a0c6d75c9523fb3",
       "instance_id":      "c733977d-a2ca-4596-9cb1-08a6e724858b",
       "dimensions": [
         {

--- a/features/filters.feature
+++ b/features/filters.feature
@@ -107,7 +107,7 @@ Feature: Filters Private Endpoints Not Enabled
       "events": null,
       "unique_timestamp": "2022-01-26T12:27:04.783936865Z",
       "last_updated": "2022-01-26T12:27:04.783936865Z",
-      "etag": "63d6683de011a71313bc4918b5e610c4099a7d49",
+      "etag": "6e627be2c355c7cebe5de4af6a0c6d75c9523fb3",
       "instance_id": "c733977d-a2ca-4596-9cb1-08a6e724858b",
       "dimensions": [
         {
@@ -137,7 +137,8 @@ Feature: Filters Private Endpoints Not Enabled
         "version": 1
       },
       "published": true,
-      "population_type": "Example"
+      "population_type": "Example",
+      "type": "flexible"
     }
     """
 

--- a/features/filters.feature
+++ b/features/filters.feature
@@ -55,6 +55,58 @@ Feature: Filters Private Endpoints Not Enabled
       }
       """
 
+    And the following version document with dataset id "cantabular-example-unpublished", edition "2021" and version "1" is available from dp-dataset-api:
+      """
+      {
+        "alerts": [],
+        "collection_id": "dfb-38b11d6c4b69493a41028d10de503aabed3728828e17e64914832d91e1f493c6",
+        "dimensions": [
+          {
+            "label": "City",
+            "links": {
+              "code_list": {},
+              "options": {},
+              "version": {}
+            },
+            "href": "http://api.localhost:23200/v1/code-lists/city",
+            "id": "city",
+            "name": "City"
+          },
+          {
+            "label": "Number of siblings (3 mappings)", 
+            "links": {
+              "code_list": {},
+              "options": {},
+              "version": {}
+            },
+            "href": "http://api.localhost:23200/v1/code-lists/siblings",
+            "id": "siblings",
+            "name": "Number of siblings (3 mappings)"
+          }
+        ],
+        "edition": "2021",
+        "id": "c733977d-a2ca-4596-9cb1-08a6e724858b",
+        "links": {
+          "dataset": {
+            "href": "http://dp-dataset-api:22000/datasets/cantabular-example-unpublished",
+            "id": "cantabular-example-1"
+          },
+          "dimensions": {},
+          "edition": {
+            "href": "http://localhost:22000/datasets/cantabular-example-unpublished/editions/2021",
+            "id": "2021"
+          },
+          "self": {
+            "href": "http://localhost:22000/datasets/cantabular-example-unpublished/editions/2021/versions/1"
+          }
+        },
+        "release_date": "2021-11-19T00:00:00.000Z",
+        "state": "associated",
+        "usage_notes": [],
+        "version": 1
+      }
+      """
+
   Scenario: Creating a new filter happy
 
     When I POST "/filters"
@@ -143,6 +195,53 @@ Feature: Filters Private Endpoints Not Enabled
     """
 
     And the HTTP status code should be "201"
+
+  Scenario: Creating a new filter unauthenticated on unpublished version
+
+    When I POST "/filters"
+    """
+    {
+      "dataset":{
+          "id":      "cantabular-example-unpublished",
+          "edition": "2021",
+          "version": 1
+      },
+      "population_type": "Example",
+      "dimensions": [
+        {
+          "name": "Number of siblings (3 mappings)",
+          "options": [
+            "0-3",
+            "4-7",
+            "7+"
+          ],
+          "dimension_url": "http://dimension.url/siblings",
+          "is_area_type": false
+        },{
+          "name": "City",
+          "options": [
+            "Cardiff",
+            "London",
+            "Swansea"
+          ],
+          "dimension_url": "http://dimension.url/city",
+          "is_area_type": true
+        }
+      ]
+
+    }
+    """
+
+    Then I should receive the following JSON response:
+    """
+    {
+      "errors": [
+        "dataset not found"
+      ]
+    }
+    """
+
+    And the HTTP status code should be "404"
 
 Scenario: Creating a new filter bad request body
 

--- a/model/filter.go
+++ b/model/filter.go
@@ -20,6 +20,7 @@ type Filter struct {
 	Dataset           Dataset            `bson:"dataset"                      json:"dataset"`
 	Published         bool               `bson:"published"                    json:"published"`
 	DisclosureControl *DisclosureControl `bson:"disclosure_control,omitempty" json:"disclosure_control,omitempty"`
+	Type              string             `bson:"type"                         json:"type"`
 	PopulationType    string             `bson:"population_type"              json:"population_type"`
 }
 


### PR DESCRIPTION
### What

- Added `type` field to filter struct
- Added check to make sure only published datasets are available to create filters on for unauthenticated users

### How to review

Check changes make sense, test pass.

To test manually (optional):
- Spin up cantabular journey services in `dp-compose/cantabular-import-journey` with the environment variables `ENABLE_PRIVATE_ENDPOINTS` and `ENABLE_PERMISSIONS_AUTH` set to `false` for `dp-cantabular-filter-flex-api` (set in `dp-cantabular-filter-flex-api.yml`)
- Import a Cantabular Flexible tabe dataset but don't publish it
- Make a request to create a new filter without authentication:`cd api/mock` edit `filter.request.json` to point to you newly imported dataset, `curl -v -d @create_filter.request.json   http://localhost:27100/filters | jq`
- Inspect response for error response `dataset not found` and http status code 404. Repeat request with authentication and you should receive 201 success response (add `-H "Authorization: $SERVICE_AUTH_TOKEN"` to curl request)
 
### Who can review

- Anyone
- Anyone familiar with the Cantabular import journey for manual testing
