### PR TITLE
use string value for IDs

### DIFF
--- a/api/filters.go
+++ b/api/filters.go
@@ -13,7 +13,6 @@ import (
 	dprequest "github.com/ONSdigital/dp-net/v2/request"
 	"github.com/ONSdigital/log.go/v2/log"
 
-	"github.com/google/uuid"
 	"github.com/pkg/errors"
 )
 
@@ -124,25 +123,12 @@ func (api *API) createFilter(w http.ResponseWriter, r *http.Request) {
 		UniqueTimestamp:   api.generate.Timestamp(),
 		LastUpdated:       api.generate.Timestamp(),
 		Dataset:           *req.Dataset,
+		InstanceID:        v.ID,
 		PopulationType:    req.PopulationType,
 		Type:              flexible,
 		Published:         v.State == published,
 		Events:            nil, // TODO: Not sure what to
 		DisclosureControl: nil, // populate for these fields yet
-	}
-
-	if f.InstanceID, err = uuid.Parse(v.ID); err != nil {
-		api.respond.Error(
-			ctx,
-			w,
-			http.StatusInternalServerError,
-			Error{
-				err:     errors.Wrap(err, "failed to parse version instance id"),
-				message: "Internal Server Error",
-				logData: log.Data{"version": v},
-			},
-		)
-		return
 	}
 
 	if err := api.store.CreateFilter(ctx, &f); err != nil {

--- a/features/filters.authorized.feature
+++ b/features/filters.authorized.feature
@@ -110,7 +110,7 @@ Feature: Filters Private Endpoints Enabled
       "events": null,
       "unique_timestamp": "2022-01-26T12:27:04.783936865Z",
       "last_updated":     "2022-01-26T12:27:04.783936865Z",
-      "etag":             "6e627be2c355c7cebe5de4af6a0c6d75c9523fb3",
+      "etag":             "adac38a98397446c01a821c6d041b2639c514f6b",
       "instance_id":      "c733977d-a2ca-4596-9cb1-08a6e724858b",
       "dimensions": [
         {

--- a/features/filters.dimensions.feature
+++ b/features/filters.dimensions.feature
@@ -19,7 +19,7 @@ Feature: Filter Dimensions Private Endpoints Not Enabled
         "events": null,
         "unique_timestamp": "2022-01-26T12:27:04.783936865Z",
         "last_updated": "2022-01-26T12:27:04.783936865Z",
-        "etag": "6e627be2c355c7cebe5de4af6a0c6d75c9523fb3",
+        "etag": "adac38a98397446c01a821c6d041b2639c514f6b",
         "instance_id": "c733977d-a2ca-4596-9cb1-08a6e724858b",
         "dimensions": [
           {

--- a/features/filters.feature
+++ b/features/filters.feature
@@ -159,7 +159,7 @@ Feature: Filters Private Endpoints Not Enabled
       "events": null,
       "unique_timestamp": "2022-01-26T12:27:04.783936865Z",
       "last_updated": "2022-01-26T12:27:04.783936865Z",
-      "etag": "6e627be2c355c7cebe5de4af6a0c6d75c9523fb3",
+      "etag": "adac38a98397446c01a821c6d041b2639c514f6b",
       "instance_id": "c733977d-a2ca-4596-9cb1-08a6e724858b",
       "dimensions": [
         {

--- a/model/filter.go
+++ b/model/filter.go
@@ -2,20 +2,18 @@ package model
 
 import (
 	"time"
-
-	"github.com/google/uuid"
 )
 
 // Filter holds details for a user filter journey
 type Filter struct {
-	ID                uuid.UUID          `bson:"filter_id"                    json:"filter_id"`
+	ID                string             `bson:"filter_id"                    json:"filter_id"`
 	Links             Links              `bson:"links"                        json:"links"`
 	FilterOutput      *FilterOutput      `bson:"filter_output,omitempty"      json:"filter_output,omitempty"`
 	Events            []Event            `bson:"events"                       json:"events"`
 	UniqueTimestamp   time.Time          `bson:"unique_timestamp"             json:"unique_timestamp"`
 	LastUpdated       time.Time          `bson:"last_updated"                 json:"last_updated"`
 	ETag              string             `bson:"etag"                         json:"etag"`
-	InstanceID        uuid.UUID          `bson:"instance_id"                  json:"instance_id"`
+	InstanceID        string             `bson:"instance_id"                  json:"instance_id"`
 	Dimensions        []Dimension        `bson:"dimensions"                   json:"dimensions"`
 	Dataset           Dataset            `bson:"dataset"                      json:"dataset"`
 	Published         bool               `bson:"published"                    json:"published"`


### PR DESCRIPTION
### What

Removed asserting filterID and instanceID as UUID as when saving to mongo we need to use string values to keep consistent with existing code (MongoDB will save UUIDs as binary rather using the stringified value)

### How to review

Check changes make sense, tests pass

### Who can review

Anyone
