### PR TITLE
Add pagination to dimensions in Filter Flex API (Ticket #5559)

### DIFF
--- a/api/contract.go
+++ b/api/contract.go
@@ -78,5 +78,14 @@ func (r *createFilterOutputRequest) Valid() error {
 
 // getFilterDimensionsResponse is the response body for GET /filters/{id}/dimensions
 type getFilterDimensionsResponse struct {
-	Dimensions []model.Dimension `json:"dimensions"`
+	Items []model.Dimension `json:"items"`
+	paginationResponse
+}
+
+// paginationResponse represents pagination data as returned to the client.
+type paginationResponse struct {
+	Limit      int `json:"limit"`
+	Offset     int `json:"offset"`
+	Count      int `json:"count"`
+	TotalCount int `json:"total_count"`
 }

--- a/api/interface.go
+++ b/api/interface.go
@@ -24,7 +24,7 @@ type datastore interface {
 	CreateFilter(context.Context, *model.Filter) error
 	GetFilter(context.Context, string) (*model.Filter, error)
 	CreateFilterOutput(context.Context, *model.FilterOutput) error
-	GetFilterDimensions(context.Context, string) ([]model.Dimension, error)
+	GetFilterDimensions(context.Context, string, int, int) ([]model.Dimension, int, error)
 }
 
 type validator interface {

--- a/api/pagination.go
+++ b/api/pagination.go
@@ -1,0 +1,60 @@
+package api
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+
+	"github.com/ONSdigital/log.go/v2/log"
+	"github.com/pkg/errors"
+)
+
+const DefaultLimit = 20
+const DefaultOffset = 0
+
+// getPaginationParams parses a URL and extracts limit/offset values.
+func getPaginationParams(url *url.URL, maximumLimit int, logData log.Data) (limit, offset int, err error) {
+	query := url.Query()
+
+	limit, err = getInt(query.Get("limit"), DefaultLimit)
+	if err != nil {
+		return 0, 0, &Error{err: err, message: "invalid parameter limit", logData: logData}
+	}
+
+	if limit > maximumLimit {
+		msg := fmt.Sprintf("limit cannot be larger than %v", maximumLimit)
+		return 0, 0, &Error{err: errors.New(msg), message: msg, logData: logData}
+	}
+
+	if limit < 0 {
+		msg := "limit cannot be less than 0"
+		return 0, 0, &Error{err: errors.New(msg), message: msg, logData: logData}
+	}
+
+	offset, err = getInt(query.Get("offset"), DefaultOffset)
+	if err != nil {
+		return 0, 0, &Error{err: err, message: "invalid parameter offset", logData: logData}
+	}
+
+	if offset < 0 {
+		msg := "offset cannot be less than 0"
+		return 0, 0, &Error{err: errors.New(msg), message: msg, logData: logData}
+	}
+
+	return
+}
+
+// getInt attempts to parse a passed string into a number, falling back to
+// a default value if no string is provided.
+func getInt(value string, fallback int) (int, error) {
+	if value == "" {
+		return fallback, nil
+	}
+
+	parsed, err := strconv.Atoi(value)
+	if err != nil {
+		return 0, errors.Wrapf(err, "cannot convert %s to int", value)
+	}
+
+	return parsed, nil
+}

--- a/api/pagination_test.go
+++ b/api/pagination_test.go
@@ -1,0 +1,86 @@
+package api
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/ONSdigital/log.go/v2/log"
+	"github.com/pkg/errors"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestGetPaginationParams(t *testing.T) {
+	Convey("Given a valid offset and limit, it parses and returns the values", t, func() {
+		parsedUrl, err := url.Parse("http://test.test?limit=10&offset=0")
+		So(err, ShouldBeNil)
+
+		limit, offset, err := getPaginationParams(parsedUrl, 100, log.Data{})
+
+		Convey("It should return the parsed values", func() {
+			So(err, ShouldBeNil)
+			So(limit, ShouldEqual, 10)
+			So(offset, ShouldEqual, 0)
+		})
+	})
+
+	Convey("Given an invalid offset or limit", t, func() {
+		tests := map[string]struct {
+			url          string
+			maximumLimit int
+		}{
+			"Limit cannot be parsed": {
+				url:          "http://test.test?limit=dog",
+				maximumLimit: 20,
+			},
+			"Offset cannot be parsed": {
+				url:          "http://test.test?offset=dog",
+				maximumLimit: 20,
+			},
+			"Limit exceeds maximum": {
+				url:          "http://test.test?limit=21",
+				maximumLimit: 20,
+			},
+			"Limit is negative": {
+				url:          "http://test.test?limit=-1",
+				maximumLimit: 20,
+			},
+			"Offset is negative": {
+				url:          "http://test.test?offset=-1",
+				maximumLimit: 20,
+			},
+		}
+
+		for desc, test := range tests {
+			Convey(desc, func() {
+				parsedUrl, err := url.Parse(test.url)
+				So(err, ShouldBeNil)
+
+				logData := log.Data{"id": "test"}
+				_, _, err = getPaginationParams(parsedUrl, test.maximumLimit, logData)
+
+				Convey("There should be an error", func() {
+					So(err, ShouldNotBeNil)
+				})
+
+				Convey("The error should contain the passed log data", func() {
+					var logErr *Error
+					ok := errors.As(err, &logErr)
+
+					So(ok, ShouldBeTrue)
+					So(logErr.LogData(), ShouldEqual, logData)
+				})
+			})
+		}
+	})
+
+	Convey("Given no pagination params, it falls back to default values", t, func() {
+		parsedUrl, err := url.Parse("http://test.test")
+		So(err, ShouldBeNil)
+
+		limit, offset, err := getPaginationParams(parsedUrl, 20, log.Data{})
+
+		So(err, ShouldBeNil)
+		So(limit, ShouldEqual, 20)
+		So(offset, ShouldEqual, 0)
+	})
+}

--- a/config/config.go
+++ b/config/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	HealthCheckInterval          time.Duration `envconfig:"HEALTHCHECK_INTERVAL"`
 	HealthCheckCriticalTimeout   time.Duration `envconfig:"HEALTHCHECK_CRITICAL_TIMEOUT"`
 	DefaultRequestTimeout        time.Duration `envconfig:"DEFAULT_REQUEST_TIMEOUT"`
+	DefaultMaximumLimit          int           `envconfig:"DEFAULT_MAXIMUM_LIMIT"`
 	ComponentTestUseLogFile      bool          `envconfig:"COMPONENT_TEST_USE_LOG_FILE"`
 	CantabularURL                string        `envconfig:"CANTABULAR_URL"`
 	CantabularExtURL             string        `envconfig:"CANTABULAR_API_EXT_URL"`
@@ -66,6 +67,7 @@ func Get() (*Config, error) {
 		HealthCheckInterval:          30 * time.Second,
 		HealthCheckCriticalTimeout:   90 * time.Second,
 		DefaultRequestTimeout:        10 * time.Second,
+		DefaultMaximumLimit:          500,
 		ComponentTestUseLogFile:      false,
 		DatasetAPIURL:                "http://localhost:22000",
 		CantabularURL:                "http://localhost:8491",

--- a/datastore/mongodb/filters.go
+++ b/datastore/mongodb/filters.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ONSdigital/dp-mongodb/v3/mongodb"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
 )
 
 // CreateFilter creates a new Filter in the CantabularFilters collection
@@ -66,22 +67,90 @@ func (c *Client) GetFilter(ctx context.Context, fID string) (*model.Filter, erro
 }
 
 // GetFilterDimensions gets the dimensions for a Filter in the CantabularFilters collection
-func (c *Client) GetFilterDimensions(ctx context.Context, fID string) ([]model.Dimension, error) {
-	var err error
-
+func (c *Client) GetFilterDimensions(ctx context.Context, fID string, limit, offset int) ([]model.Dimension, int, error) {
 	col := c.collections.filters
 
-	var f model.Filter
-
-	if err = c.conn.Collection(col.name).FindOne(ctx, bson.M{"filter_id": fID}, &f); err != nil {
-		err := &er{
-			err: errors.Wrap(err, "failed to find filter"),
-		}
-		if errors.Is(err, mongodb.ErrNoDocumentFound) {
-			err.notFound = true
-		}
-		return nil, err
+	// Paginates the nested dimensions field
+	dimensionsFacet := bson.A{
+		bson.D{{"$replaceRoot", bson.D{{"newRoot", "$dimensions"}}}},
+		bson.D{{"$sort", bson.D{{"name", 1}}}},
+		bson.D{{"$limit", limit}},
+		bson.D{{"$skip", offset}},
 	}
 
-	return f.Dimensions, nil
+	// Adds a total record count for all a filter's dimensions
+	paginationFacet := bson.A{
+		bson.D{{"$count", "totalCount"}},
+	}
+
+	// Adds the filter-found flag
+	foundFacet := bson.A{
+		bson.D{{"$project", bson.D{{"found", "$foundFilters"}}}},
+	}
+
+	facet := bson.D{{
+		"$facet",
+		bson.D{
+			{"dimensions", dimensionsFacet},
+			{"pagination", paginationFacet},
+			{"foundFilters", foundFacet},
+		},
+	}}
+
+	// Flatten lists where we know there is only one value, or all values are equal
+	flatten := bson.D{
+		{"$addFields", bson.D{
+			{"pagination", bson.D{{"$arrayElemAt", bson.A{"$pagination", 0}}}},
+			{"foundFilters", bson.D{{"$arrayElemAt", bson.A{"$foundFilters", 0}}}},
+		}},
+	}
+
+	pipeline := mongo.Pipeline{
+		bson.D{{"$match", bson.D{{"filter_id", fID}}}},
+		// Add a flag to indicate if a filter was set. Since stages run on matched rows,
+		// if no row was found this will never be set, and will deserialize into `false`.
+		bson.D{{"$addFields", bson.D{{"foundFilters", true}}}},
+		bson.D{{"$unwind", "$dimensions"}},
+		facet,
+		flatten,
+	}
+
+	var results []dimensionQueryResult
+	if err := c.conn.Collection(col.name).Aggregate(ctx, pipeline, &results); err != nil {
+		return nil, 0, &er{
+			err: errors.Wrap(err, "failed to get filter dimensions"),
+		}
+	}
+
+	if len(results) == 0 {
+		return nil, 0, errors.Errorf("no results found in aggregate query: %v", results)
+	}
+
+	result := results[0]
+
+	if !result.FoundFilters.Found {
+		return nil, 0, &er{
+			err:      errors.Errorf("failed to find filter with ID (%s)", fID),
+			notFound: true,
+		}
+	}
+
+	return result.Dimensions, result.Pagination.TotalCount, nil
+}
+
+// foundFilters contains a bool indicating if there were any row matches.
+// We need this to distinguish between zero dimensions (which is not an error)
+// and zero matched filters (which is an error).
+type foundFilters struct {
+	Found bool `bson:"found"`
+}
+
+type paginationQueryResult struct {
+	TotalCount int `bson:"totalCount"`
+}
+
+type dimensionQueryResult struct {
+	Dimensions   []model.Dimension     `bson:"dimensions"`
+	Pagination   paginationQueryResult `bson:"pagination"`
+	FoundFilters foundFilters          `bson:"foundFilters"`
 }

--- a/features/create_filter.authorized.feature
+++ b/features/create_filter.authorized.feature
@@ -21,7 +21,7 @@ Feature: Filters Private Endpoints Enabled
             "name": "City"
           },
           {
-            "label": "Number of siblings (3 mappings)", 
+            "label": "Number of siblings (3 mappings)",
             "links": {
               "code_list": {},
               "options": {},
@@ -58,9 +58,9 @@ Feature: Filters Private Endpoints Enabled
 
   Scenario: Creating a new filter journey when authorized
     Given I am identified as "user@ons.gov.uk"
-    
+
     And I am authorised
-    
+
     When I POST "/filters"
     """
     {
@@ -193,9 +193,9 @@ Feature: Filters Private Endpoints Enabled
 
   Scenario: Creating a new filter journey when not authorized
     Given I am not identified
-    
+
     And I am not authorised
-    
+
     When I POST "/filters"
     """
     {"foo":"bar"}

--- a/features/create_filter.feature
+++ b/features/create_filter.feature
@@ -21,7 +21,7 @@ Feature: Filters Private Endpoints Not Enabled
             "name": "City"
           },
           {
-            "label": "Number of siblings (3 mappings)", 
+            "label": "Number of siblings (3 mappings)",
             "links": {
               "code_list": {},
               "options": {},
@@ -73,7 +73,7 @@ Feature: Filters Private Endpoints Not Enabled
             "name": "City"
           },
           {
-            "label": "Number of siblings (3 mappings)", 
+            "label": "Number of siblings (3 mappings)",
             "links": {
               "code_list": {},
               "options": {},

--- a/features/filters.dimensions.feature
+++ b/features/filters.dimensions.feature
@@ -58,7 +58,17 @@ Feature: Filter Dimensions Private Endpoints Not Enabled
     Then I should receive the following JSON response:
     """
     {
-      "dimensions": [
+      "items": [
+        {
+          "name": "City",
+          "options": [
+            "Cardiff",
+            "London",
+            "Swansea"
+          ],
+          "dimension_url": "http://dimension.url/city",
+          "is_area_type": true
+        },
         {
           "name": "Number of siblings (3 mappings)",
           "options": [
@@ -68,7 +78,22 @@ Feature: Filter Dimensions Private Endpoints Not Enabled
           ],
           "dimension_url": "http://dimension.url/siblings",
           "is_area_type": false
-        },
+        }
+      ],
+      "count": 2,
+      "offset": 0,
+      "limit": 20,
+      "total_count": 2
+    }
+    """
+    And the HTTP status code should be "200"
+
+  Scenario: Get paginated filter dimensions successfully (limit)
+    When I GET "/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions?limit=1"
+    Then I should receive the following JSON response:
+    """
+    {
+      "items": [
         {
           "name": "City",
           "options": [
@@ -79,7 +104,36 @@ Feature: Filter Dimensions Private Endpoints Not Enabled
           "dimension_url": "http://dimension.url/city",
           "is_area_type": true
         }
-      ]
+      ],
+      "count": 1,
+      "offset": 0,
+      "limit": 1,
+      "total_count": 2
+    }
+    """
+    And the HTTP status code should be "200"
+
+  Scenario: Get paginated filter dimensions successfully (offset)
+    When I GET "/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions?offset=1"
+    Then I should receive the following JSON response:
+    """
+    {
+      "items": [
+        {
+          "name": "Number of siblings (3 mappings)",
+          "options": [
+            "0-3",
+            "4-7",
+            "7+"
+          ],
+          "dimension_url": "http://dimension.url/siblings",
+          "is_area_type": false
+        }
+      ],
+      "count": 1,
+      "offset": 1,
+      "limit": 20,
+      "total_count": 2
     }
     """
     And the HTTP status code should be "200"
@@ -93,3 +147,55 @@ Feature: Filter Dimensions Private Endpoints Not Enabled
     }
     """
     And the HTTP status code should be "404"
+
+  Scenario: Get filter dimensions unsuccessfully (cannot parse offset)
+    When I GET "/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions?offset=dog"
+    Then I should receive the following JSON response:
+    """
+    {
+      "errors": ["invalid parameter offset"]
+    }
+    """
+    And the HTTP status code should be "400"
+
+  Scenario: Get filter dimensions unsuccessfully (cannot parse limit)
+    When I GET "/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions?limit=dog"
+    Then I should receive the following JSON response:
+    """
+    {
+      "errors": ["invalid parameter limit"]
+    }
+    """
+    And the HTTP status code should be "400"
+
+  Scenario: Get filter dimensions unsuccessfully (invalid limit, too large)
+    Given the maximum pagination limit is set to 100
+    When I GET "/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions?limit=101"
+    Then I should receive the following JSON response:
+    """
+    {
+      "errors": ["limit cannot be larger than 100"]
+    }
+    """
+    And the HTTP status code should be "400"
+
+  Scenario: Get filter dimensions unsuccessfully (invalid limit, less than 0)
+    When I GET "/filters/94310d8d-72d6-492a-03cb-27584627edb1/dimensions?limit=-1"
+    Then I should receive the following JSON response:
+    """
+    {
+      "errors": ["limit cannot be less than 0"]
+    }
+    """
+    And the HTTP status code should be "400"
+
+  Scenario: Get filter dimensions unsuccessfully (invalid offset, less than 0)
+    When I GET "/filters/94310d8d-72d6-492a-03cb-27584627edb1/dimensions?offset=-1"
+    Then I should receive the following JSON response:
+    """
+    {
+      "errors": ["offset cannot be less than 0"]
+    }
+    """
+    And the HTTP status code should be "400"
+

--- a/features/filters.dimensions.feature
+++ b/features/filters.dimensions.feature
@@ -138,6 +138,20 @@ Feature: Filter Dimensions Private Endpoints Not Enabled
     """
     And the HTTP status code should be "200"
 
+  Scenario: Get paginated filter dimensions successfully (0 limit)
+    When I GET "/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions?limit=0"
+    Then I should receive the following JSON response:
+    """
+    {
+      "items": [],
+      "count": 0,
+      "offset": 0,
+      "limit": 0,
+      "total_count": 2
+    }
+    """
+    And the HTTP status code should be "200"
+
   Scenario: Get filter dimensions unsuccessfully
     When I GET "/filters/94310d8d-72d6-492a-03cb-27584627edb1/dimensions"
     Then I should receive the following JSON response:

--- a/features/steps/steps.go
+++ b/features/steps/steps.go
@@ -27,6 +27,10 @@ func (c *Component) RegisterSteps(ctx *godog.ScenarioContext) {
 		c.privateEndpointsAreNotEnabled,
 	)
 	ctx.Step(
+		`^the maximum pagination limit is set to (\d+)$`,
+		c.theMaximumLimitIsSetTo,
+	)
+	ctx.Step(
 		`^the document in the database for id "([^"]*)" should be:$`,
 		c.theDocumentInTheDatabaseShouldBe,
 	)
@@ -77,6 +81,11 @@ func (c *Component) privateEndpointsAreNotEnabled() error {
 func (c *Component) theDocumentInTheDatabaseShouldBe(id string, doc *godog.DocString) error {
 	// TODO: implement step for verifying documents stored in Mongo. No prior
 	// art of this being done properly in ONS yet so save to be done in future ticket
+	return nil
+}
+
+func (c *Component) theMaximumLimitIsSetTo(val int) error {
+	c.cfg.DefaultMaximumLimit = val
 	return nil
 }
 

--- a/service/interface.go
+++ b/service/interface.go
@@ -51,7 +51,7 @@ type Datastore interface {
 	CreateFilter(context.Context, *model.Filter) error
 	GetFilter(context.Context, string) (*model.Filter, error)
 	CreateFilterOutput(context.Context, *model.FilterOutput) error
-	GetFilterDimensions(context.Context, string) ([]model.Dimension, error)
+	GetFilterDimensions(context.Context, string, int, int) ([]model.Dimension, int, error)
 	Checker(context.Context, *healthcheck.CheckState) error
 	Conn() *mongo.MongoConnection
 }

--- a/service/mock/datastore.go
+++ b/service/mock/datastore.go
@@ -37,7 +37,7 @@ var _ service.Datastore = &DatastoreMock{}
 // 			GetFilterFunc: func(contextMoqParam context.Context, s string) (*model.Filter, error) {
 // 				panic("mock out the GetFilter method")
 // 			},
-// 			GetFilterDimensionsFunc: func(contextMoqParam context.Context, s string) ([]model.Dimension, error) {
+// 			GetFilterDimensionsFunc: func(contextMoqParam context.Context, s string, n1 int, n2 int) ([]model.Dimension, int, error) {
 // 				panic("mock out the GetFilterDimensions method")
 // 			},
 // 		}
@@ -63,7 +63,7 @@ type DatastoreMock struct {
 	GetFilterFunc func(contextMoqParam context.Context, s string) (*model.Filter, error)
 
 	// GetFilterDimensionsFunc mocks the GetFilterDimensions method.
-	GetFilterDimensionsFunc func(contextMoqParam context.Context, s string) ([]model.Dimension, error)
+	GetFilterDimensionsFunc func(contextMoqParam context.Context, s string, n1 int, n2 int) ([]model.Dimension, int, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -104,6 +104,10 @@ type DatastoreMock struct {
 			ContextMoqParam context.Context
 			// S is the s argument value.
 			S string
+			// N1 is the n1 argument value.
+			N1 int
+			// N2 is the n2 argument value.
+			N2 int
 		}
 	}
 	lockChecker             sync.RWMutex
@@ -281,21 +285,25 @@ func (mock *DatastoreMock) GetFilterCalls() []struct {
 }
 
 // GetFilterDimensions calls GetFilterDimensionsFunc.
-func (mock *DatastoreMock) GetFilterDimensions(contextMoqParam context.Context, s string) ([]model.Dimension, error) {
+func (mock *DatastoreMock) GetFilterDimensions(contextMoqParam context.Context, s string, n1 int, n2 int) ([]model.Dimension, int, error) {
 	if mock.GetFilterDimensionsFunc == nil {
 		panic("DatastoreMock.GetFilterDimensionsFunc: method is nil but Datastore.GetFilterDimensions was just called")
 	}
 	callInfo := struct {
 		ContextMoqParam context.Context
 		S               string
+		N1              int
+		N2              int
 	}{
 		ContextMoqParam: contextMoqParam,
 		S:               s,
+		N1:              n1,
+		N2:              n2,
 	}
 	mock.lockGetFilterDimensions.Lock()
 	mock.calls.GetFilterDimensions = append(mock.calls.GetFilterDimensions, callInfo)
 	mock.lockGetFilterDimensions.Unlock()
-	return mock.GetFilterDimensionsFunc(contextMoqParam, s)
+	return mock.GetFilterDimensionsFunc(contextMoqParam, s, n1, n2)
 }
 
 // GetFilterDimensionsCalls gets all the calls that were made to GetFilterDimensions.
@@ -304,10 +312,14 @@ func (mock *DatastoreMock) GetFilterDimensions(contextMoqParam context.Context, 
 func (mock *DatastoreMock) GetFilterDimensionsCalls() []struct {
 	ContextMoqParam context.Context
 	S               string
+	N1              int
+	N2              int
 } {
 	var calls []struct {
 		ContextMoqParam context.Context
 		S               string
+		N1              int
+		N2              int
 	}
 	mock.lockGetFilterDimensions.RLock()
 	calls = mock.calls.GetFilterDimensions

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -36,10 +36,13 @@ parameters:
     name: limit
     description: >-
       Limit the number of items that will be returned. Defaults to 20 and capped
-      at 1000
+      at 500
     in: query
     required: false
     type: integer
+    default: 20
+    minimum: 0
+    maximum: 500
   offset:
     name: offset
     description: >-
@@ -48,6 +51,8 @@ parameters:
     in: query
     required: false
     type: integer
+    default: 0
+    minimum: 0
   name:
     name: name
     type: string
@@ -245,21 +250,42 @@ paths:
   /filters/{id}/dimensions:
     get:
       tags:
-       - "Public"
+        - "Public"
       summary: "Get all dimensions used in this filter"
       description: |
         Return a list of all dimensions which are going to be used to filter on
       parameters:
-      - $ref: '#/parameters/filter_id'
-      - $ref: '#/parameters/page_limit'
-      - $ref: '#/parameters/offset'
+        - $ref: '#/parameters/filter_id'
+        - $ref: '#/parameters/page_limit'
+        - $ref: '#/parameters/offset'
       responses:
         200:
           description: "A list of dimension URLs"
           schema:
-            type: array
-            items:
-              $ref: '#/definitions/DimensionOptions'
+            type: object
+            properties:
+              items:
+                type: array
+                items:
+                  $ref: '#/definitions/DimensionOptions'
+              limit:
+                type: number
+                example: 100
+              offset:
+                type: number
+                example: 0
+              count:
+                type: number
+                example: 100
+              total_count:
+                type: number
+                example: 500
+            required:
+              - dimensions
+              - limit
+              - offset
+              - count
+              - total_count
           headers:
             ETag:
               type: string
@@ -270,13 +296,13 @@ paths:
           $ref: '#/responses/InternalError'
     put:
       tags:
-       - "Public"
+        - "Public"
       summary: "Update dimensions and options used in this filter"
       description: |
         Updates a list of dimensions and options that have been selected by the user
       parameters:
-      - $ref: '#/parameters/filter_id'
-      - $ref: '#/parameters/dimension_options'
+        - $ref: '#/parameters/filter_id'
+        - $ref: '#/parameters/dimension_options'
       responses:
         200:
           description: "A list of dimension URLs"
@@ -615,14 +641,14 @@ definitions:
         type: string
         description: The name of the dimension that triggers the disclosure rules
       blockedoptions:
-         $ref: '#/definitions/BlockedOptions'
+        $ref: '#/definitions/BlockedOptions'
   BlockedOptions:
     type: object
     properties:
       blocked_options:
         type: array
         items:
-            type: string
+          type: string
         description: A list of blocked options applicable to the dimension
       blocked_count:
         type: integer


### PR DESCRIPTION
### What

Updates the dimensions endpoint to conform to the ONS pagination standards.

Since dimensions are nested inside filters, we used `unwind` and `facet` to pull out the relevant info. Unlike `findOne`, aggregates always seem to return a list of results, and therefore don't seem to provide an easy way for us to determine if the top-level filter is missing. We've added a flag which gets set in the event that any matches are returned, but another alternative would be running a separate `Count()` query first.

(First time working with Mongo, so any alternatives/suggestions welcome.)

This is effectively a breaking change, since it renames `dimensions` to `items`. However, the client is [already set up](https://github.com/ONSdigital/dp-api-clients-go/blob/2b9ec3cde38ebe3b0e37971bff49cf154969f566/filter/data.go#L14) to look for items (and therefore never returns any results), so it should be safe to change.

Resolves: [5559](https://trello.com/c/vsEwaNIe)

### How to review

Create a filter on a dataset, then paginate through the results by changing the `offset`/`limit` query params.

Example: `http://localhost:27100/filters/4661c9a7-d24d-4c30-be71-8aa6cb72b9e9/dimensions?limit=1&offset=0`

```json
{
    "items": [
        {
            "name": "City",
            "options": [
                "0"
            ],
            "dimension_url": "http://localhost:22000/datasets/cantabular-flexible-example/editions/2021/versions/1/dimensions/city/options",
            "is_area_type": true
        }
    ],
    "limit": 1,
    "offset": 0,
    "count": 1,
    "total_count": 2
}
```

### Who can review

Anyone.
