### PR TITLE
Added support for PUT filters/{id}

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -51,6 +51,7 @@ func New(ctx context.Context, cfg *config.Config, r chi.Router, idc *identity.Cl
 func (api *API) enablePublicEndpoints() {
 	api.Router.Post("/filters", api.createFilter)
 	api.Router.Get("/filters/{id}", api.getFilter)
+	api.Router.Put("/filters/{id}", api.putFilter)
 	api.Router.Get("/filters/{id}/dimensions", api.getFilterDimensions)
 	api.Router.Post("/filters/{id}/dimensions", api.addFilterDimension)
 }
@@ -67,9 +68,9 @@ func (api *API) enablePrivateEndpoints() {
 
 	r.Post("/filters", api.createFilter)
 	r.Get("/filters/{id}", api.getFilter)
+	r.Put("/filters/{id}", api.putFilter)
 	r.Get("/filters/{id}/dimensions", api.getFilterDimensions)
 	r.Post("/filters/{id}/dimensions", api.addFilterDimension)
-
 	r.Post("/filter-outputs", api.createFilterOutput)
 	api.Router.Mount("/", r)
 }

--- a/api/contract.go
+++ b/api/contract.go
@@ -50,6 +50,11 @@ type getFilterResponse struct {
 	model.Filter
 }
 
+// putFilterResponse is the response body for PUT /filters/{id}
+type putFilterResponse struct {
+	model.PutFilter
+}
+
 // createFilterOutputResponse is the response body for POST /filters
 type createFilterOutputResponse struct {
 	model.FilterOutput

--- a/api/filters.go
+++ b/api/filters.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/ONSdigital/dp-api-clients-go/v2/cantabular"
 	"github.com/ONSdigital/dp-api-clients-go/v2/dataset"
@@ -324,6 +325,31 @@ func (api *API) hashFilterDimensions(ctx context.Context, fID string) (string, e
 		return "", err
 	}
 	return fmt.Sprintf("%x", h.Sum(nil)), nil
+}
+
+func (api *API) putFilter(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	time, _ := time.Parse(time.RFC3339, "2016-07-17T08:38:25.316Z")
+
+	resp := putFilterResponse{
+		model.PutFilter{
+			Events: []model.Event{
+				{
+					Timestamp: time,
+					Name:      "cantabular-export-start",
+				},
+			},
+			Dataset: model.Dataset{
+				ID:      "string",
+				Edition: "string",
+				Version: 0,
+			},
+			PopulationType: "string",
+		},
+	}
+
+	api.respond.JSON(ctx, w, http.StatusOK, resp)
 }
 
 func (api *API) getFilterDimensions(w http.ResponseWriter, r *http.Request) {

--- a/api/mock/create_filter-outputs.request.develop.json
+++ b/api/mock/create_filter-outputs.request.develop.json
@@ -1,0 +1,38 @@
+{
+    "state": "published",
+    "downloads": 
+    {
+        "xls": 
+        {
+          "href":"http://localhost:23600/downloads/datasets/cantabular-flexible-example/editions/2021/versions/1.xls",
+          "private":"http://minio:9000/private-bucket/datasets/cantabular-flexible-example-2021-1.xls",
+          "size":"6944",
+          "public":"https://csv-exported.s3.eu-west-1.amazonaws.com/full-datasets/cpih01-time-series-v1.csv-metadata.xls",
+          "skipped":true
+        },
+        "csv":
+        {
+          "href":"http://localhost:23600/downloads/datasets/cantabular-flexible-example/editions/2021/versions/1.csv",
+          "private":"http://minio:9000/private-bucket/datasets/cantabular-flexible-example-2021-1.csv",
+          "public":"https://csv-exported.s3.eu-west-1.amazonaws.com/full-datasets/cpih01-time-series-v1.csv-metadata.csv",
+          "size":"277",
+          "skipped":true
+        },
+        "csvw":
+        {
+          "href" : "http://localhost:23600/downloads/datasets/cantabular-flexible-example/editions/2021/versions/1.csv-metadata.json",
+          "private" : "http://minio:9000/private-bucket/datasets/cantabular-flexible-example-2021-1.csvw",
+          "public" : "https://csv-exported.s3.eu-west-1.amazonaws.com/full-datasets/cpih01-time-series-v1.csv-metadata.csvw",
+          "size" : "607",
+          "skipped": true
+        },
+        "txt":
+        {
+          "href" : "http://localhost:23600/downloads/datasets/cantabular-flexible-example/editions/2021/versions/1.txt",
+          "private" : "http://minio:9000/private-bucket/datasets/cantabular-flexible-example-2021-1.txt",
+          "public" : "https://csv-exported.s3.eu-west-1.amazonaws.com/full-datasets/cpih01-time-series-v1.csv-metadata.txt",
+          "size" : "530",
+          "skipped": true
+        }
+    }
+}

--- a/features/put_filter.feature
+++ b/features/put_filter.feature
@@ -1,0 +1,123 @@
+Feature: Put Filter Private Endpoints Not Enabled
+
+  Background:
+    Given private endpoints are not enabled
+
+    And I have these filters:
+    """
+    [
+      {
+        "filter_id": "94310d8d-72d6-492a-bc30-27584627edb1",
+        "links": {
+          "version": {
+            "href": "http://mockhost:9999/datasets/cantabular-example-1/editions/2021/version/1",
+            "id": "1"
+          },
+          "self": {
+            "href": ":27100/filters/94310d8d-72d6-492a-bc30-27584627edb1"
+          }
+        },
+        "events": null,
+        "instance_id": "c733977d-a2ca-4596-9cb1-08a6e724858b",
+        "dimensions": [
+          {
+            "name": "Number of siblings (3 mappings)",
+            "options": [
+              "0-3",
+              "4-7",
+              "7+"
+            ],
+            "dimension_url": "http://dimension.url/siblings",
+            "is_area_type": false
+          },
+          {
+            "name": "City",
+            "options": [
+              "Cardiff",
+              "London",
+              "Swansea"
+            ],
+            "dimension_url": "http://dimension.url/city",
+            "is_area_type": true
+          }
+        ],
+        "dataset": {
+          "id": "cantabular-example-1",
+          "edition": "2021",
+          "version": 1
+        },
+        "published": true,
+        "population_type": "Example",
+        "type": "flexible"
+      },
+      {
+        "filter_id": "83210d8d-72d6-492a-bc30-27584627abc2",
+        "links": {
+          "version": {
+            "href": "http://mockhost:9999/datasets/cantabular-example-unpublished/editions/2021/version/1",
+            "id": "1"
+          },
+          "self": {
+            "href": ":27100/filters/83210d8d-72d6-492a-bc30-27584627abc2"
+          }
+        },
+        "events": null,
+        "instance_id": "c733977d-a2ca-4596-9cb1-08a6e724858b",
+        "dimensions": [
+          {
+            "name": "Number of siblings (3 mappings)",
+            "options": [
+              "0-3",
+              "4-7",
+              "7+"
+            ],
+            "dimension_url": "http://dimension.url/siblings",
+            "is_area_type": false
+          },
+          {
+            "name": "City",
+            "options": [
+              "Cardiff",
+              "London",
+              "Swansea"
+            ],
+            "dimension_url": "http://dimension.url/city",
+            "is_area_type": true
+          }
+        ],
+        "dataset": {
+          "id": "cantabular-example-unpublished",
+          "edition": "2021",
+          "version": 1
+        },
+        "published": false,
+        "population_type": "Example",
+        "type": "flexible"
+      }
+    ]
+    """
+
+  Scenario: PUT filter successfully
+    When I PUT "/filters/94310d8d-72d6-492a-bc30-27584627edb1"
+    """
+    """
+    Then I should receive the following JSON response:
+    """
+    {
+      "events": [
+        {
+          "timestamp": "2016-07-17T08:38:25.316Z",
+          "name": "cantabular-export-start"
+        }
+      ],
+      "dataset": {
+        "id": "string",
+        "edition": "string",
+        "version": 0
+      },
+      "population_type": "string"
+    }
+    """
+    And the HTTP status code should be "200"
+
+  

--- a/model/filter.go
+++ b/model/filter.go
@@ -26,6 +26,13 @@ type Filter struct {
 	PopulationType    string              `bson:"population_type"              json:"population_type"`
 }
 
+//PutFilter holds details for PUT filter response
+type PutFilter struct {
+	Events         []Event `bson:"events"                       json:"events"`
+	Dataset        Dataset `bson:"dataset"                      json:"dataset"`
+	PopulationType string  `bson:"population_type"              json:"population_type"`
+}
+
 type Links struct {
 	Version Link `bson:"version" json:"version"`
 	Self    Link `bson:"self"    json:"self"`


### PR DESCRIPTION
### What
Added skeleton PUT endpoint for filters/{id}. Currently the endpoint will just return a predefined response

### How to review
1. The response matches the swagger spec of response
2. api/mock/create_filter-outputs.request.develop.json this is not related to this commit, but is part of testing the filter outputs in develop

### Who can review

Anyone
