### PR TITLE
Update filter response model

### DIFF
--- a/api/contract.go
+++ b/api/contract.go
@@ -42,7 +42,10 @@ func (r *createFilterRequest) Valid() error {
 
 // createFilterResponse is the response body for POST /filters
 type createFilterResponse struct {
-	model.Filter
+	model.JobState
+	Links          model.Links   `json:"links"`
+	Dataset        model.Dataset `json:"dataset"`
+	PopulationType string        `json:"population_type"`
 }
 
 // getFilterDimensionsResponse is the response body for GET /filters/{id}

--- a/api/contract.go
+++ b/api/contract.go
@@ -58,9 +58,16 @@ type putFilterResponse struct {
 	model.PutFilter
 }
 
-// createFilterOutputResponse is the response body for POST /filters
+// createFilterOutputResponse is the response body for POST /filters-output
 type createFilterOutputResponse struct {
 	model.FilterOutput
+}
+
+// filterOutputResponse is the response body for PUT /filters-outputs
+type filterOutputResponse struct {
+	model.FilterOutput
+	model.JobState
+	Links model.FilterOutputLinks `json:"links"`
 }
 
 // createFilterOutputRequest is the request body for POST /filters

--- a/api/filters.go
+++ b/api/filters.go
@@ -110,7 +110,15 @@ func (api *API) createFilter(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := createFilterResponse{
-		Filter: f,
+		model.JobState{
+			InstanceID:       f.InstanceID,
+			DimensionListUrl: fmt.Sprintf("%s/filters/%s/dimensions", api.cfg.BindAddr, f.ID),
+			FilterID:         f.ID,
+			Events:           f.Events,
+		},
+		f.Links,
+		f.Dataset,
+		f.PopulationType,
 	}
 
 	api.respond.JSON(ctx, w, http.StatusCreated, resp)

--- a/features/create_filter.authorized.feature
+++ b/features/create_filter.authorized.feature
@@ -109,36 +109,13 @@ Feature: Filters Private Endpoints Enabled
       },
       "events": null,
       "instance_id":      "c733977d-a2ca-4596-9cb1-08a6e724858b",
-      "dimensions": [
-        {
-          "name": "Number of siblings (3 mappings)",
-          "options": [
-            "0-3",
-            "4-7",
-            "7+"
-          ],
-          "dimension_url": "http://dimension.url/siblings",
-          "is_area_type":  false
-        },
-        {
-          "name": "City",
-          "options": [
-            "Cardiff",
-            "London",
-            "Swansea"
-          ],
-          "dimension_url": "http://dimension.url/city",
-          "is_area_type":  true
-        }
-      ],
+      "dimension_list_url":":27100/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions",
       "dataset": {
         "id":      "cantabular-example-1",
         "edition": "2021",
         "version": 1
       },
-      "published":       true,
-      "population_type": "Example",
-      "type": "flexible"
+      "population_type": "Example"
     }
     """
 

--- a/features/create_filter.feature
+++ b/features/create_filter.feature
@@ -158,36 +158,13 @@ Feature: Filters Private Endpoints Not Enabled
       },
       "events": null,
       "instance_id": "c733977d-a2ca-4596-9cb1-08a6e724858b",
-      "dimensions": [
-        {
-          "name": "Number of siblings (3 mappings)",
-          "options": [
-            "0-3",
-            "4-7",
-            "7+"
-          ],
-          "dimension_url": "http://dimension.url/siblings",
-          "is_area_type": false
-        },
-        {
-          "name": "City",
-          "options": [
-            "Cardiff",
-            "London",
-            "Swansea"
-          ],
-          "dimension_url": "http://dimension.url/city",
-          "is_area_type": true
-        }
-      ],
+      "dimension_list_url":":27100/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions",
       "dataset": {
         "id": "cantabular-example-1",
         "edition": "2021",
         "version": 1
       },
-      "published": true,
-      "population_type": "Example",
-      "type": "flexible"
+      "population_type": "Example"
     }
     """
 

--- a/model/filter.go
+++ b/model/filter.go
@@ -33,6 +33,13 @@ type PutFilter struct {
 	PopulationType string  `bson:"population_type"              json:"population_type"`
 }
 
+type JobState struct {
+	InstanceID       string  `json:"instance_id"`
+	DimensionListUrl string  `json:"dimension_list_url"`
+	FilterID         string  `json:"filter_id"`
+	Events           []Event `json:"events"`
+}
+
 type Links struct {
 	Version Link `bson:"version" json:"version"`
 	Self    Link `bson:"self"    json:"self"`

--- a/model/filter.go
+++ b/model/filter.go
@@ -45,6 +45,11 @@ type Links struct {
 	Self    Link `bson:"self"    json:"self"`
 }
 
+type FilterOutputLinks struct {
+	Links
+	FilterBlueprint Link `json:"filter_blueprint"`
+}
+
 type Link struct {
 	HREF string `bson:"href"           json:"href"`
 	ID   string `bson:"id,omitempty"   json:"id,omitempty"`


### PR DESCRIPTION
### What

* Update the POST /filters response model
Significant changes:
   * include a `population_type` based on [this PR](https://github.com/ONSdigital/dp-cantabular-filter-flex-api/pull/31/files#diff-8b1949772e223a1da6a2049ada2733fa506410975b241cf86cf44c7a8665bc62R531)
   * Removal of dimensions list and replace that with an URL to get the
   filter dimensions instead
   * remove `published` and `type`

* Create a new Filter Output response
This will be used when we implement a new `PUT /filter-output` endpoint

### How to review

run tests and review swagger.json

### Who to review

any developer
