### PR TITLE
Add GET filter dimension endpoint (#5570)

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -57,6 +57,7 @@ func (api *API) enablePublicEndpoints() {
 	api.Router.Put("/filters/{id}", api.putFilter)
 	api.Router.Post("/filters/{id}/submit", api.submitFilter)
 	api.Router.Get("/filters/{id}/dimensions", api.getFilterDimensions)
+	api.Router.Get("/filters/{id}/dimensions/{dimension}", api.getFilterDimension)
 	api.Router.Post("/filters/{id}/dimensions", api.addFilterDimension)
 	api.Router.Get("/flex/datasets/{dataset_id}/editions/{edition}/versions/{version}/json", api.getDatasetJSON)
 	api.Router.Get("/filter-outputs/{filter-output-id}", api.getFilterOutput)
@@ -77,6 +78,7 @@ func (api *API) enablePrivateEndpoints() {
 	r.Put("/filters/{id}", api.putFilter)
 	r.Post("/filters/{id}/submit", api.submitFilter)
 	r.Get("/filters/{id}/dimensions", api.getFilterDimensions)
+	r.Get("/filters/{id}/dimensions/{dimension}", api.getFilterDimension)
 	r.Post("/filters/{id}/dimensions", api.addFilterDimension)
 
 	r.Get("/filter-outputs/{filter-output-id}", api.getFilterOutput)

--- a/api/contract.go
+++ b/api/contract.go
@@ -152,6 +152,11 @@ func (items *dimensionItems) fromDimensions(dims []model.Dimension, host, filter
 	}
 }
 
+type getFilterDimensionResponse struct {
+	dimensionItem
+	IsAreaType bool `json:"is_area_type"`
+}
+
 type dimensionItemLinks struct {
 	Filter  model.Link `json:"filter"`
 	Options model.Link `json:"options"`

--- a/api/interface.go
+++ b/api/interface.go
@@ -29,6 +29,7 @@ type datastore interface {
 	UpdateFilterOutput(context.Context, *model.FilterOutput) error
 	AddFilterOutputEvent(context.Context, string, *model.Event) error
 	GetFilterDimensions(context.Context, string, int, int) ([]model.Dimension, int, error)
+	GetFilterDimension(ctx context.Context, fID, dimName string) (model.Dimension, error)
 	AddFilterDimension(context.Context, string, model.Dimension) error
 }
 

--- a/features/filters.dimension.authorised.feature
+++ b/features/filters.dimension.authorised.feature
@@ -149,6 +149,44 @@ Feature: Filter Outputs Private Endpoints Enabled
     """
     And the HTTP status code should be "200"
 
+  Scenario: Get a specific filter dimension successfully
+    Given I am identified as "user@ons.gov.uk"
+    And I am authorised
+    When I GET "/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/geography"
+    Then I should receive the following JSON response:
+    """
+    {
+      "name": "geography",
+      "is_area_type": true,
+      "links": {
+        "filter": {
+          "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1",
+          "id": "94310d8d-72d6-492a-bc30-27584627edb1"
+        },
+        "options": {
+          "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/geography/options"
+        },
+        "self": {
+          "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/geography",
+          "id": "geography"
+        }
+      }
+    }
+    """
+    And the HTTP status code should be "200"
+
+  Scenario: Get a specific filter dimension when the filter is not present
+    Given I am identified as "user@ons.gov.uk"
+    And I am authorised
+    When I GET "/filters/00000000-0000-0000-0000-000000000000/dimensions/geography"
+    Then the HTTP status code should be "400"
+
+  Scenario: Get a specific filter dimension when the dimension is not present
+    Given I am identified as "user@ons.gov.uk"
+    And I am authorised
+    When I GET "/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/other"
+    Then the HTTP status code should be "404"
+
   Scenario: Add a filter dimension successfully
     Given I am identified as "user@ons.gov.uk"
     And I am authorised

--- a/features/filters.dimensions.feature
+++ b/features/filters.dimensions.feature
@@ -148,6 +148,38 @@ Feature: Filter Dimensions Private Endpoints Not Enabled
     """
     And the HTTP status code should be "200"
 
+  Scenario: Get a specific filter dimension successfully
+    When I GET "/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/geography"
+    Then I should receive the following JSON response:
+    """
+    {
+      "name": "geography",
+      "is_area_type": true,
+      "links": {
+        "filter": {
+          "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1",
+          "id": "94310d8d-72d6-492a-bc30-27584627edb1"
+        },
+        "options": {
+          "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/geography/options"
+        },
+        "self": {
+          "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/geography",
+          "id": "geography"
+        }
+      }
+    }
+    """
+    And the HTTP status code should be "200"
+
+  Scenario: Get a specific filter dimension when the filter is not present
+    When I GET "/filters/00000000-0000-0000-0000-000000000000/dimensions/geography"
+    Then the HTTP status code should be "400"
+
+  Scenario: Get a specific filter dimension when the dimension is not present
+    When I GET "/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/other"
+    Then the HTTP status code should be "404"
+
   Scenario: Add a filter dimension successfully 
     When I POST "/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions"
     """

--- a/service/interface.go
+++ b/service/interface.go
@@ -55,6 +55,7 @@ type Datastore interface {
 	GetFilterOutput(context.Context, string) (*model.FilterOutput, error)
 	AddFilterOutputEvent(context.Context, string, *model.Event) error
 	GetFilterDimensions(context.Context, string, int, int) ([]model.Dimension, int, error)
+	GetFilterDimension(ctx context.Context, fID, dimName string) (model.Dimension, error)
 	AddFilterDimension(ctx context.Context, s string, dimension model.Dimension) error
 	Checker(context.Context, *healthcheck.CheckState) error
 	Conn() *mongo.MongoConnection

--- a/service/mock/datastore.go
+++ b/service/mock/datastore.go
@@ -5,12 +5,11 @@ package mock
 
 import (
 	"context"
-	"sync"
-
 	"github.com/ONSdigital/dp-cantabular-filter-flex-api/model"
 	"github.com/ONSdigital/dp-cantabular-filter-flex-api/service"
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
 	mongo "github.com/ONSdigital/dp-mongodb/v3/mongodb"
+	"sync"
 )
 
 // Ensure, that DatastoreMock does implement service.Datastore.
@@ -19,46 +18,49 @@ var _ service.Datastore = &DatastoreMock{}
 
 // DatastoreMock is a mock implementation of service.Datastore.
 //
-//	func TestSomethingThatUsesDatastore(t *testing.T) {
+// 	func TestSomethingThatUsesDatastore(t *testing.T) {
 //
-//		// make and configure a mocked service.Datastore
-//		mockedDatastore := &DatastoreMock{
-//			AddFilterDimensionFunc: func(ctx context.Context, s string, dimension model.Dimension) error {
-//				panic("mock out the AddFilterDimension method")
-//			},
-//			AddFilterOutputEventFunc: func(contextMoqParam context.Context, s string, event *model.Event) error {
-//				panic("mock out the AddFilterOutputEvent method")
-//			},
-//			CheckerFunc: func(contextMoqParam context.Context, checkState *healthcheck.CheckState) error {
-//				panic("mock out the Checker method")
-//			},
-//			ConnFunc: func() *mongo.MongoConnection {
-//				panic("mock out the Conn method")
-//			},
-//			CreateFilterFunc: func(contextMoqParam context.Context, filter *model.Filter) error {
-//				panic("mock out the CreateFilter method")
-//			},
-//			CreateFilterOutputFunc: func(contextMoqParam context.Context, filterOutput *model.FilterOutput) error {
-//				panic("mock out the CreateFilterOutput method")
-//			},
-//			GetFilterFunc: func(contextMoqParam context.Context, s string) (*model.Filter, error) {
-//				panic("mock out the GetFilter method")
-//			},
-//			GetFilterDimensionsFunc: func(contextMoqParam context.Context, s string, n1 int, n2 int) ([]model.Dimension, int, error) {
-//				panic("mock out the GetFilterDimensions method")
-//			},
-//			GetFilterOutputFunc: func(contextMoqParam context.Context, s string) (*model.FilterOutput, error) {
-//				panic("mock out the GetFilterOutput method")
-//			},
-//			UpdateFilterOutputFunc: func(contextMoqParam context.Context, filterOutput *model.FilterOutput) error {
-//				panic("mock out the UpdateFilterOutput method")
-//			},
-//		}
+// 		// make and configure a mocked service.Datastore
+// 		mockedDatastore := &DatastoreMock{
+// 			AddFilterDimensionFunc: func(ctx context.Context, s string, dimension model.Dimension) error {
+// 				panic("mock out the AddFilterDimension method")
+// 			},
+// 			AddFilterOutputEventFunc: func(contextMoqParam context.Context, s string, event *model.Event) error {
+// 				panic("mock out the AddFilterOutputEvent method")
+// 			},
+// 			CheckerFunc: func(contextMoqParam context.Context, checkState *healthcheck.CheckState) error {
+// 				panic("mock out the Checker method")
+// 			},
+// 			ConnFunc: func() *mongo.MongoConnection {
+// 				panic("mock out the Conn method")
+// 			},
+// 			CreateFilterFunc: func(contextMoqParam context.Context, filter *model.Filter) error {
+// 				panic("mock out the CreateFilter method")
+// 			},
+// 			CreateFilterOutputFunc: func(contextMoqParam context.Context, filterOutput *model.FilterOutput) error {
+// 				panic("mock out the CreateFilterOutput method")
+// 			},
+// 			GetFilterFunc: func(contextMoqParam context.Context, s string) (*model.Filter, error) {
+// 				panic("mock out the GetFilter method")
+// 			},
+// 			GetFilterDimensionFunc: func(ctx context.Context, fID string, dimName string) (model.Dimension, error) {
+// 				panic("mock out the GetFilterDimension method")
+// 			},
+// 			GetFilterDimensionsFunc: func(contextMoqParam context.Context, s string, n1 int, n2 int) ([]model.Dimension, int, error) {
+// 				panic("mock out the GetFilterDimensions method")
+// 			},
+// 			GetFilterOutputFunc: func(contextMoqParam context.Context, s string) (*model.FilterOutput, error) {
+// 				panic("mock out the GetFilterOutput method")
+// 			},
+// 			UpdateFilterOutputFunc: func(contextMoqParam context.Context, filterOutput *model.FilterOutput) error {
+// 				panic("mock out the UpdateFilterOutput method")
+// 			},
+// 		}
 //
-//		// use mockedDatastore in code that requires service.Datastore
-//		// and then make assertions.
+// 		// use mockedDatastore in code that requires service.Datastore
+// 		// and then make assertions.
 //
-//	}
+// 	}
 type DatastoreMock struct {
 	// AddFilterDimensionFunc mocks the AddFilterDimension method.
 	AddFilterDimensionFunc func(ctx context.Context, s string, dimension model.Dimension) error
@@ -80,6 +82,9 @@ type DatastoreMock struct {
 
 	// GetFilterFunc mocks the GetFilter method.
 	GetFilterFunc func(contextMoqParam context.Context, s string) (*model.Filter, error)
+
+	// GetFilterDimensionFunc mocks the GetFilterDimension method.
+	GetFilterDimensionFunc func(ctx context.Context, fID string, dimName string) (model.Dimension, error)
 
 	// GetFilterDimensionsFunc mocks the GetFilterDimensions method.
 	GetFilterDimensionsFunc func(contextMoqParam context.Context, s string, n1 int, n2 int) ([]model.Dimension, int, error)
@@ -141,6 +146,15 @@ type DatastoreMock struct {
 			// S is the s argument value.
 			S string
 		}
+		// GetFilterDimension holds details about calls to the GetFilterDimension method.
+		GetFilterDimension []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// FID is the fID argument value.
+			FID string
+			// DimName is the dimName argument value.
+			DimName string
+		}
 		// GetFilterDimensions holds details about calls to the GetFilterDimensions method.
 		GetFilterDimensions []struct {
 			// ContextMoqParam is the contextMoqParam argument value.
@@ -167,16 +181,16 @@ type DatastoreMock struct {
 			FilterOutput *model.FilterOutput
 		}
 	}
-
 	lockAddFilterDimension   sync.RWMutex
+	lockAddFilterOutputEvent sync.RWMutex
 	lockChecker              sync.RWMutex
 	lockConn                 sync.RWMutex
 	lockCreateFilter         sync.RWMutex
 	lockCreateFilterOutput   sync.RWMutex
 	lockGetFilter            sync.RWMutex
+	lockGetFilterDimension   sync.RWMutex
 	lockGetFilterDimensions  sync.RWMutex
 	lockGetFilterOutput      sync.RWMutex
-	lockAddFilterOutputEvent sync.RWMutex
 	lockUpdateFilterOutput   sync.RWMutex
 }
 
@@ -421,6 +435,45 @@ func (mock *DatastoreMock) GetFilterCalls() []struct {
 	mock.lockGetFilter.RLock()
 	calls = mock.calls.GetFilter
 	mock.lockGetFilter.RUnlock()
+	return calls
+}
+
+// GetFilterDimension calls GetFilterDimensionFunc.
+func (mock *DatastoreMock) GetFilterDimension(ctx context.Context, fID string, dimName string) (model.Dimension, error) {
+	if mock.GetFilterDimensionFunc == nil {
+		panic("DatastoreMock.GetFilterDimensionFunc: method is nil but Datastore.GetFilterDimension was just called")
+	}
+	callInfo := struct {
+		Ctx     context.Context
+		FID     string
+		DimName string
+	}{
+		Ctx:     ctx,
+		FID:     fID,
+		DimName: dimName,
+	}
+	mock.lockGetFilterDimension.Lock()
+	mock.calls.GetFilterDimension = append(mock.calls.GetFilterDimension, callInfo)
+	mock.lockGetFilterDimension.Unlock()
+	return mock.GetFilterDimensionFunc(ctx, fID, dimName)
+}
+
+// GetFilterDimensionCalls gets all the calls that were made to GetFilterDimension.
+// Check the length with:
+//     len(mockedDatastore.GetFilterDimensionCalls())
+func (mock *DatastoreMock) GetFilterDimensionCalls() []struct {
+	Ctx     context.Context
+	FID     string
+	DimName string
+} {
+	var calls []struct {
+		Ctx     context.Context
+		FID     string
+		DimName string
+	}
+	mock.lockGetFilterDimension.RLock()
+	calls = mock.calls.GetFilterDimension
+	mock.lockGetFilterDimension.RUnlock()
 	return calls
 }
 

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -343,7 +343,7 @@ paths:
         200:
           description: "A Dimension within a filter was returned"
           schema:
-            $ref: '#/definitions/DimensionItem'
+            $ref: '#/definitions/DimensionItemWithArea'
           headers:
             ETag:
               type: string
@@ -994,6 +994,13 @@ definitions:
         type: string
       links:
         $ref: "#/definitions/DimensionItemLinks"
+  DimensionItemWithArea:
+    allOf:
+      - $ref: "#/definitions/DimensionItem"
+      - type: object
+        properties:
+          is_area_type:
+            type: boolean
   DimensionItems:
     type: array
     items:


### PR DESCRIPTION
### What

Adds an endpoint to get a single dimension: `GET /filters/:filter/dimensions/:dimension`

We include the `is_area_type` flag so the frontend can switch on it. Going to revisit this later, but adding in now to fix the frontend journey which uses it.

Resolves: [5570](https://trello.com/c/8xCrDyR1)

### How to review

Check the endpoint matches the schema and ticket requirements.

### Who can review

Anyone.
