### PR TITLE
fix: Kafka config definition changed back

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -7,6 +7,9 @@ import (
 	"github.com/kelseyhightower/envconfig"
 )
 
+// KafkaTLSProtocolFlag informs service to use TLS protocol for kafka
+const KafkaTLSProtocolFlag = "TLS"
+
 // Config represents service configuration for dp-cantabular-filter-flex-api
 type Config struct {
 	BindAddr                     string        `envconfig:"BIND_ADDR"`
@@ -19,7 +22,7 @@ type Config struct {
 	CantabularURL                string        `envconfig:"CANTABULAR_URL"`
 	CantabularExtURL             string        `envconfig:"CANTABULAR_API_EXT_URL"`
 	DatasetAPIURL                string        `envconfig:"DATASET_API_URL"`
-	FilterAPIURL                 string        `envconfig:"FILTER_API_URL"` 
+	FilterAPIURL                 string        `envconfig:"FILTER_API_URL"`
 	FiltersCollection            string        `envconfig:"FILTERS_COLLECTION"`
 	FilterOutputsCollection      string        `envconfig:"FILTER_OUTPUTS_COLLECTION"`
 	EnablePrivateEndpoints       bool          `envconfig:"ENABLE_PRIVATE_ENDPOINTS"`

--- a/service/kafka.go
+++ b/service/kafka.go
@@ -17,7 +17,7 @@ func GetKafkaProducer(ctx context.Context, cfg *config.Config) (kafka.IProducer,
 		MaxMessageBytes:   &cfg.KafkaConfig.MaxBytes,
 	}
 
-	if cfg.KafkaConfig.TLSProtocolFlag {
+	if cfg.KafkaConfig.SecProtocol == config.KafkaTLSProtocolFlag {
 		pConfig.SecurityConfig = kafka.GetSecurityConfig(
 			cfg.KafkaConfig.SecCACerts,
 			cfg.KafkaConfig.SecClientCert,


### PR DESCRIPTION
### What

In the work previously, the configuration definition
was mistakenly changed. This changes it back to
the cantabular-csv-exporter-service definition.


### How to review

run `make test-component` and `make test`
please review the shape of the config struct and the 
`kafka` logic, and confirm that they are right for the service. 

### Who can review

Team B
