### PR TITLE
Fix/filter submit

### DIFF
--- a/api/filters.go
+++ b/api/filters.go
@@ -141,7 +141,7 @@ func (api *API) submitFilter(w http.ResponseWriter, r *http.Request) {
 	}
 
 	filterOutput := model.FilterOutput{
-		FilterID: filter.Dataset.ID,
+		FilterID: filter.ID,
 		State:    model.Submitted,
 	}
 
@@ -163,7 +163,7 @@ func (api *API) submitFilter(w http.ResponseWriter, r *http.Request) {
 	// naively converting for now.
 	version := strconv.Itoa(filter.Dataset.Version)
 
-	e := event.ExportStart {
+	e := event.ExportStart{
 		InstanceID:     filter.InstanceID,
 		DatasetID:      filter.Dataset.ID,
 		Edition:        filter.Dataset.Edition,
@@ -196,7 +196,7 @@ func (api *API) submitFilter(w http.ResponseWriter, r *http.Request) {
 		// TODO: apparently events are only relevant for filter outputs and
 		// AFAIK are not related to kafka events. Also do we really want to expose
 		// the details of our Kafka topic names etc to the public?
-		Events:         []model.Event{
+		Events: []model.Event{
 			{
 				Timestamp: api.generate.Timestamp().Format(time.RFC3339),
 				Name:      "cantabular-export-start",

--- a/features/steps/steps.go
+++ b/features/steps/steps.go
@@ -97,6 +97,20 @@ func (c *Component) RegisterSteps(ctx *godog.ScenarioContext) {
 		`^Cantabular responds with an error$`,
 		c.cantabularRespondsWithAnError,
 	)
+
+	ctx.Step(`^the filter output with the id "([^"]*)" is in the datastore`,
+		c.filterOutputIsInDatastore)
+
+}
+func (c *Component) filterOutputIsInDatastore(id string) error {
+
+	_, err := c.store.GetFilterOutput(c.ctx, id)
+	if err != nil {
+		return fmt.Errorf("Error encountered while retrieving filter output.")
+	}
+
+	return nil
+
 }
 
 // iShouldReceiveAnErrorsArray checks that the response body can be deserialized into

--- a/features/submit_filter.feature
+++ b/features/submit_filter.feature
@@ -138,7 +138,7 @@ Feature: Submit Filter Private Endpoints Not Enabled
 
     """
     And the HTTP status code should be "202"
-
+    And the filter output with the id "94310d8d-72d6-492a-bc30-27584627edb1" is in the datastore
     And the following Export Start events are produced:
       | InstanceID        | DatasetID            | Edition          | Version | FilterOutputID                       |
       | TEST-INSTANCE-ID  | cantabular-example-1 | 2021             | 1       | 94310d8d-72d6-492a-bc30-27584627edb1 |


### PR DESCRIPTION
### What

The filter submit endpoint erroneously set the `filterID` field of the Filter output as `dataset.id`. 
This was corrected. 

A step for the submit endpoint was added to check that a filteroutput with the correct id was persisted in mongo


### How to review

run `make test` and `make test-component`

### Who can review

TEAM B 
