### PR TITLE
Add ID/Label to stored filters (#5664)

### DIFF
--- a/api/contract.go
+++ b/api/contract.go
@@ -44,6 +44,14 @@ func (r *createFilterRequest) Valid() error {
 		if len(d.Name) == 0 {
 			return fmt.Errorf("missing field: [dimension[%d].name]", i)
 		}
+
+		if len(d.ID) != 0 {
+			return fmt.Errorf("unexpected field id provided for: %s", d.Name)
+		}
+
+		if len(d.Label) != 0 {
+			return fmt.Errorf("unexpected field label provided for: %s", d.Name)
+		}
 	}
 
 	return nil

--- a/api/contract.go
+++ b/api/contract.go
@@ -121,13 +121,28 @@ type addFilterDimensionResponse struct {
 	dimensionItem
 }
 
+// updateFilterDimensionResponse is the request body for PUT /filters/{id}/dimensions/{name}
+type updateFilterDimensionRequest struct {
+	model.Dimension
+}
+
+func (u *updateFilterDimensionRequest) Valid() error {
+	if len(u.ID) == 0 {
+		return errors.New("missing field: [id]")
+	}
+
+	return nil
+}
+
 // updateFilterDimensionResponse is the response body for PUT /filters/{id}/dimensions/{name}
 type updateFilterDimensionResponse struct {
 	dimensionItem
 }
 
 type dimensionItem struct {
+	ID    string             `json:"id"`
 	Name  string             `json:"name"`
+	Label string             `json:"label"`
 	Links dimensionItemLinks `json:"links"`
 }
 
@@ -135,11 +150,13 @@ func (d *dimensionItem) fromDimension(dim model.Dimension, host, filterID string
 	filterURL := fmt.Sprintf("%s/filters/%s", host, filterID)
 	dimURL := fmt.Sprintf("%s/dimensions/%s", filterURL, dim.Name)
 
+	d.ID = dim.ID
 	d.Name = dim.Name
+	d.Label = dim.Label
 	d.Links = dimensionItemLinks{
 		Self: model.Link{
 			HREF: dimURL,
-			ID:   dim.Name,
+			ID:   dim.ID,
 		},
 		Filter: model.Link{
 			HREF: filterURL,

--- a/api/filters.go
+++ b/api/filters.go
@@ -371,7 +371,9 @@ func (api *API) addFilterDimension(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := api.store.AddFilterDimension(ctx, fID, req.Dimension); err != nil {
+	dim := hydrateDimensions([]model.Dimension{req.Dimension}, v.Dimensions)[0]
+
+	if err := api.store.AddFilterDimension(ctx, fID, dim); err != nil {
 		api.respond.Error(
 			ctx,
 			w,
@@ -386,7 +388,7 @@ func (api *API) addFilterDimension(w http.ResponseWriter, r *http.Request) {
 
 	var resp addFilterDimensionResponse
 	resp.dimensionItem.fromDimension(
-		req.Dimension,
+		dim,
 		api.cfg.FilterAPIURL,
 		fID,
 	)

--- a/api/filters.go
+++ b/api/filters.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/ONSdigital/dp-api-clients-go/v2/cantabular"
+	"github.com/ONSdigital/dp-api-clients-go/v2/cantabular/gql"
 	"github.com/ONSdigital/dp-api-clients-go/v2/dataset"
 	dperrors "github.com/ONSdigital/dp-cantabular-filter-flex-api/errors"
 	"github.com/ONSdigital/dp-cantabular-filter-flex-api/event"
@@ -433,11 +434,14 @@ func (api *API) updateFilterDimension(w http.ResponseWriter, r *http.Request) {
 		"dimension_name": dimensionName,
 	}
 
-	dim := model.Dimension{
-		Options: []string{},
+	req := updateFilterDimensionRequest{
+		Dimension: model.Dimension{
+			Name:    dimensionName,
+			Options: []string{},
+		},
 	}
 
-	if err := api.ParseRequest(r.Body, &dim); err != nil {
+	if err := api.ParseRequest(r.Body, &req); err != nil {
 		api.respond.Error(
 			ctx,
 			w,
@@ -452,7 +456,8 @@ func (api *API) updateFilterDimension(w http.ResponseWriter, r *http.Request) {
 
 	// The new dimension won't be present on the dataset (i.e. only `City` will be present, not `Country`),
 	// so instead of validating it against the existing Version, we check to see if the dimension exists in Cantabular.
-	if err := api.validateCantabularDimensionExists(ctx, filterID, dim.Name); err != nil {
+	node, err := api.getCantabularDimension(ctx, filterID, req.ID)
+	if err != nil {
 		api.respond.Error(
 			ctx,
 			w,
@@ -465,12 +470,15 @@ func (api *API) updateFilterDimension(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// ID/name is provided by the request, but the label is provided by Cantabular.
+	req.Label = node.Label
+
 	var eTag string
 	if reqETag := api.getETag(r); reqETag != eTagAny {
 		eTag = reqETag
 	}
 
-	newETag, err := api.store.UpdateFilterDimension(ctx, filterID, dimensionName, dim, eTag)
+	newETag, err := api.store.UpdateFilterDimension(ctx, filterID, dimensionName, req.Dimension, eTag)
 	if err != nil {
 		api.respond.Error(
 			ctx,
@@ -485,7 +493,7 @@ func (api *API) updateFilterDimension(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := updateFilterDimensionResponse{}
-	resp.fromDimension(dim, api.cfg.FilterAPIURL, filterID)
+	resp.fromDimension(req.Dimension, api.cfg.FilterAPIURL, filterID)
 
 	w.Header().Set(eTagHeader, newETag)
 
@@ -680,12 +688,12 @@ func (api *API) isValidDatasetDimensions(w http.ResponseWriter, ctx context.Cont
 	return true
 }
 
-// validateCantabularDimensionExists checks that dimension exists in Cantabular by searching for it.
+// getCantabularDimension checks that dimension exists in Cantabular by searching for it.
 // If the dimension doesn't exist, or couldn't be retrieved, an error is returned.
-func (api *API) validateCantabularDimensionExists(ctx context.Context, filterID, dimensionName string) error {
+func (api *API) getCantabularDimension(ctx context.Context, filterID, dimensionName string) (*gql.Node, error) {
 	filter, err := api.store.GetFilter(ctx, filterID)
 	if err != nil {
-		return Error{
+		return nil, Error{
 			err:        errors.Wrap(err, "error retrieving filter"),
 			message:    "failed to get filter dimensions",
 			badRequest: true,
@@ -697,18 +705,18 @@ func (api *API) validateCantabularDimensionExists(ctx context.Context, filterID,
 		Text:    dimensionName,
 	})
 	if err != nil {
-		return errors.Wrap(err, "error in cantabular response")
+		return nil, errors.Wrap(err, "error in cantabular response")
 	}
 
 	if len(foundDimensions.Dataset.Variables.Search.Edges) == 0 {
-		return Error{
+		return nil, Error{
 			err:      errors.New("no dimensions in response"),
 			notFound: true,
 			logData:  log.Data{"found_dimensions": foundDimensions},
 		}
 	}
 
-	return nil
+	return &foundDimensions.Dataset.Variables.Search.Edges[0].Node, nil
 }
 
 // validateDimensions validates provided filter dimensions exist within the dataset dimensions provided.

--- a/datastore/mongodb/filter_dimensions.go
+++ b/datastore/mongodb/filter_dimensions.go
@@ -174,6 +174,7 @@ func (c *Client) UpdateFilterDimension(ctx context.Context, filterID string, dim
 	updateFilter := bson.M{
 		"$set": bson.M{
 			"etag":         filter.ETag,
+			"last_updated": c.generate.Timestamp(),
 			"dimensions.$": dimension,
 		},
 	}

--- a/datastore/mongodb/interface.go
+++ b/datastore/mongodb/interface.go
@@ -1,11 +1,14 @@
 package mongodb
 
 import (
+	"time"
+
 	"github.com/google/uuid"
 )
 
 type generator interface {
 	UUID() (uuid.UUID, error)
+	Timestamp() time.Time
 }
 
 type hasher interface {

--- a/features/create_filter.authorized.feature
+++ b/features/create_filter.authorized.feature
@@ -121,7 +121,7 @@ Feature: Filters Private Endpoints Enabled
 
     And the HTTP status code should be "201"
 
-    And the document in the database for id "94310d8d-72d6-492a-bc30-27584627edb1" should be:
+    And the document in the database for id "94310d8d-72d6-492a-bc30-27584627edb1" should match:
     """
     {
       "filter_id": "94310d8d-72d6-492a-bc30-27584627edb1",
@@ -138,7 +138,9 @@ Feature: Filters Private Endpoints Enabled
       "instance_id": "c733977d-a2ca-4596-9cb1-08a6e724858b",
       "dimensions": [
         {
-          "name": "Number of siblings (3 mappings)",
+          "name": "siblings",
+          "id": "siblings_3",
+          "label": "Number of siblings (3 mappings)",
           "options": [
             "0-3",
             "4-7",
@@ -148,7 +150,9 @@ Feature: Filters Private Endpoints Enabled
           "is_area_type":  false
         },
         {
-          "name": "City",
+          "name": "geography",
+          "id": "city",
+          "label": "City",
           "options": [
             "Cardiff",
             "London",

--- a/features/create_filter.authorized.feature
+++ b/features/create_filter.authorized.feature
@@ -121,9 +121,10 @@ Feature: Filters Private Endpoints Enabled
 
     And the HTTP status code should be "201"
 
-    And the document in the database for id "94310d8d-72d6-492a-bc30-27584627edb1" should match:
+    And a document in collection "filters" with key "filter_id" value "94310d8d-72d6-492a-bc30-27584627edb1" should match:
     """
     {
+      "_id": "94310d8d-72d6-492a-bc30-27584627edb1",
       "filter_id": "94310d8d-72d6-492a-bc30-27584627edb1",
       "links": {
         "version": {
@@ -137,7 +138,7 @@ Feature: Filters Private Endpoints Enabled
           "href": ":27100/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions"
         }
       },
-      "events": null,
+      "etag": "e70f6470a26c2379b591b34e47e50321879abcbc",
       "instance_id": "c733977d-a2ca-4596-9cb1-08a6e724858b",
       "dimensions": [
         {
@@ -149,7 +150,6 @@ Feature: Filters Private Endpoints Enabled
             "4-7",
             "7+"
           ],
-          "dimension_url": "http://dimension.url/siblings",
           "is_area_type":  false
         },
         {
@@ -161,18 +161,30 @@ Feature: Filters Private Endpoints Enabled
             "London",
             "Swansea"
           ],
-          "dimension_url": "http://dimension.url/city",
           "is_area_type":  true
         }
       ],
       "dataset": {
-        "id":      "cantabular-example-1",
+        "id": "cantabular-example-1",
         "edition": "2021",
-        "version": 1
+        "version": {
+          "$numberInt":"1"
+        }
       },
       "published": true,
       "type": "flexible",
-      "population_type": "Example"
+      "population_type": "Example",
+      "unique_timestamp":{
+        "$timestamp":{
+          "i":1,
+          "t":1.643200024e+09
+        }
+      },
+      "last_updated":{
+        "$date":{
+          "$numberLong":"1643200024783"
+        }
+      }
     }
     """
 

--- a/features/create_filter.authorized.feature
+++ b/features/create_filter.authorized.feature
@@ -132,6 +132,9 @@ Feature: Filters Private Endpoints Enabled
         },
         "self": {
           "href": ":27100/filters/94310d8d-72d6-492a-bc30-27584627edb1"
+        },
+        "dimensions": {
+          "href": ":27100/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions"
         }
       },
       "events": null,
@@ -163,11 +166,12 @@ Feature: Filters Private Endpoints Enabled
         }
       ],
       "dataset": {
-        "id":      "c7b634c9-b4e9-4e7a-a0b8-d255d38db200",
+        "id":      "cantabular-example-1",
         "edition": "2021",
         "version": 1
       },
-      "published":       true,
+      "published": true,
+      "type": "flexible",
       "population_type": "Example"
     }
     """

--- a/features/create_filter.feature
+++ b/features/create_filter.feature
@@ -137,7 +137,6 @@ Feature: Filters Private Endpoints Not Enabled
           "is_area_type": true
         }
       ]
-
     }
     """
 
@@ -171,6 +170,58 @@ Feature: Filters Private Endpoints Not Enabled
 
     And the HTTP status code should be "201"
 
+    And the document in the database for id "94310d8d-72d6-492a-bc30-27584627edb1" should match:
+    """
+    {
+      "filter_id": "94310d8d-72d6-492a-bc30-27584627edb1",
+      "links": {
+        "version": {
+          "href": "http://mockhost:9999/datasets/cantabular-example-1/editions/2021/version/1",
+          "id": "1"
+        },
+        "self": {
+          "href": ":27100/filters/94310d8d-72d6-492a-bc30-27584627edb1"
+        },
+        "dimensions": {
+          "href": ":27100/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions"
+        }
+      },
+      "instance_id": "c733977d-a2ca-4596-9cb1-08a6e724858b",
+      "dataset": {
+        "id": "cantabular-example-1",
+        "edition": "2021",
+        "version": 1
+      },
+      "dimensions": [
+        {
+          "name": "siblings",
+          "id": "siblings_3",
+          "label": "Number of siblings (3 mappings)",
+          "options": [
+            "0-3",
+            "4-7",
+            "7+"
+          ],
+          "is_area_type": false
+        },
+        {
+          "name": "geography",
+          "id": "city",
+          "label": "City",
+          "options": [
+            "Cardiff",
+            "London",
+            "Swansea"
+          ],
+          "is_area_type": true
+        }
+      ],
+      "population_type": "Example",
+      "published": true,
+      "type": "flexible"
+    }
+    """
+
   Scenario: Creating a new filter unauthenticated on unpublished version
 
     When I POST "/filters"
@@ -201,7 +252,6 @@ Feature: Filters Private Endpoints Not Enabled
           "is_area_type": true
         }
       ]
-
     }
     """
 
@@ -216,7 +266,7 @@ Feature: Filters Private Endpoints Not Enabled
 
     And the HTTP status code should be "404"
 
-Scenario: Creating a new filter bad request body
+  Scenario: Creating a new filter bad request body
 
     When I POST "/filters"
     """
@@ -232,6 +282,85 @@ Scenario: Creating a new filter bad request body
       ]
     }
     """
+
+    And the HTTP status code should be "400"
+
+  Scenario: Creating a new filter (invalid request, passing id)
+
+    When I POST "/filters"
+    """
+    {
+      "dataset":{
+        "id":      "cantabular-example-1",
+        "edition": "2021",
+        "version": 1
+      },
+      "population_type": "Example",
+      "dimensions": [
+        {
+          "id": "siblings_3",
+          "name": "siblings",
+          "options": [
+            "0-3",
+            "4-7",
+            "7+"
+          ],
+          "is_area_type": false
+        },{
+          "id": "city",
+          "label": "City",
+          "name": "geography",
+          "options": [
+            "Cardiff",
+            "London",
+            "Swansea"
+          ],
+          "is_area_type": true
+        }
+      ]
+    }
+    """
+
+    Then I should receive an errors array
+
+    And the HTTP status code should be "400"
+
+  Scenario: Creating a new filter (invalid request, passing label)
+
+    When I POST "/filters"
+    """
+    {
+      "dataset":{
+        "id":      "cantabular-example-1",
+        "edition": "2021",
+        "version": 1
+      },
+      "population_type": "Example",
+      "dimensions": [
+        {
+          "label": "Number of Siblings (3 mappings)",
+          "name": "siblings",
+          "options": [
+            "0-3",
+            "4-7",
+            "7+"
+          ],
+          "is_area_type": false
+        },{
+          "label": "City",
+          "name": "geography",
+          "options": [
+            "Cardiff",
+            "London",
+            "Swansea"
+          ],
+          "is_area_type": true
+        }
+      ]
+    }
+    """
+
+    Then I should receive an errors array
 
     And the HTTP status code should be "400"
 

--- a/features/create_filter.feature
+++ b/features/create_filter.feature
@@ -170,9 +170,10 @@ Feature: Filters Private Endpoints Not Enabled
 
     And the HTTP status code should be "201"
 
-    And the document in the database for id "94310d8d-72d6-492a-bc30-27584627edb1" should match:
+    And a document in collection "filters" with key "filter_id" value "94310d8d-72d6-492a-bc30-27584627edb1" should match:
     """
     {
+      "_id": "94310d8d-72d6-492a-bc30-27584627edb1",
       "filter_id": "94310d8d-72d6-492a-bc30-27584627edb1",
       "links": {
         "version": {
@@ -186,11 +187,14 @@ Feature: Filters Private Endpoints Not Enabled
           "href": ":27100/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions"
         }
       },
+      "etag": "e70f6470a26c2379b591b34e47e50321879abcbc",
       "instance_id": "c733977d-a2ca-4596-9cb1-08a6e724858b",
       "dataset": {
         "id": "cantabular-example-1",
         "edition": "2021",
-        "version": 1
+        "version": {
+          "$numberInt":"1"
+        }
       },
       "dimensions": [
         {
@@ -218,7 +222,18 @@ Feature: Filters Private Endpoints Not Enabled
       ],
       "population_type": "Example",
       "published": true,
-      "type": "flexible"
+      "type": "flexible",
+      "unique_timestamp":{
+        "$timestamp":{
+          "i":1,
+          "t":1.643200024e+09
+        }
+      },
+      "last_updated":{
+        "$date":{
+          "$numberLong":"1643200024783"
+        }
+      }
     }
     """
 

--- a/features/filters.dimension.authorised.feature
+++ b/features/filters.dimension.authorised.feature
@@ -71,6 +71,8 @@ Feature: Filter Outputs Private Endpoints Enabled
         "dimensions": [
           {
             "name": "siblings",
+            "id": "siblings_3",
+            "label": "Number of siblings (3 mappings)",
             "options": [
               "0-3",
               "4-7",
@@ -80,6 +82,8 @@ Feature: Filter Outputs Private Endpoints Enabled
           },
           {
             "name": "geography",
+            "id": "city",
+            "label": "City",
             "options": [
               "Cardiff",
               "London",
@@ -110,6 +114,8 @@ Feature: Filter Outputs Private Endpoints Enabled
       "items": [
         {
           "name": "geography",
+          "id": "city",
+          "label": "City",
           "links": {
             "filter": {
               "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1",
@@ -120,12 +126,14 @@ Feature: Filter Outputs Private Endpoints Enabled
             },
             "self": {
               "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/geography",
-              "id": "geography"
+              "id": "city"
             }
           }
         },
         {
           "name": "siblings",
+          "id": "siblings_3",
+          "label": "Number of siblings (3 mappings)",
           "links": {
             "filter": {
               "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1",
@@ -136,7 +144,7 @@ Feature: Filter Outputs Private Endpoints Enabled
             },
             "self": {
               "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/siblings",
-              "id": "siblings"
+              "id": "siblings_3"
             }
           }
         }
@@ -157,6 +165,8 @@ Feature: Filter Outputs Private Endpoints Enabled
     """
     {
       "name": "geography",
+      "id": "city",
+      "label": "City",
       "is_area_type": true,
       "links": {
         "filter": {
@@ -168,7 +178,7 @@ Feature: Filter Outputs Private Endpoints Enabled
         },
         "self": {
           "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/geography",
-          "id": "geography"
+          "id": "city"
         }
       }
     }
@@ -204,6 +214,8 @@ Feature: Filter Outputs Private Endpoints Enabled
     """
     {
       "name": "siblings",
+      "id": "siblings_3",
+      "label": "Number of siblings (3 mappings)",
       "links": {
         "filter": {
           "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1",
@@ -214,7 +226,7 @@ Feature: Filter Outputs Private Endpoints Enabled
         },
         "self": {
           "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/siblings",
-          "id": "siblings"
+          "id": "siblings_3"
         }
       }
     }
@@ -239,6 +251,8 @@ Feature: Filter Outputs Private Endpoints Enabled
     """
     {
       "name": "siblings",
+      "id": "siblings_3",
+      "label": "Number of siblings (3 mappings)",
       "links": {
         "filter": {
           "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1",
@@ -249,7 +263,7 @@ Feature: Filter Outputs Private Endpoints Enabled
         },
         "self": {
           "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/siblings",
-          "id": "siblings"
+          "id": "siblings_3"
         }
       }
     }
@@ -349,6 +363,8 @@ Feature: Filter Outputs Private Endpoints Enabled
       "items": [
         {
           "name": "geography",
+          "id": "city",
+          "label": "City",
           "links": {
             "filter": {
               "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1",
@@ -359,7 +375,7 @@ Feature: Filter Outputs Private Endpoints Enabled
             },
             "self": {
               "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/geography",
-              "id": "geography"
+              "id": "city"
             }
           }
         }
@@ -382,6 +398,8 @@ Feature: Filter Outputs Private Endpoints Enabled
       "items": [
         {
           "name": "siblings",
+          "id": "siblings_3",
+          "label": "Number of siblings (3 mappings)",
           "links": {
             "filter": {
               "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1",
@@ -392,7 +410,7 @@ Feature: Filter Outputs Private Endpoints Enabled
             },
             "self": {
               "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/siblings",
-              "id": "siblings"
+              "id": "siblings_3"
             }
           }
         }

--- a/features/filters.dimensions.feature
+++ b/features/filters.dimensions.feature
@@ -72,6 +72,8 @@ Feature: Filter Dimensions Private Endpoints Not Enabled
         "dimensions": [
           {
             "name": "siblings",
+            "id": "siblings_3",
+            "label": "Number of siblings (3 mappings)",
             "options": [
               "0-3",
               "4-7",
@@ -81,6 +83,8 @@ Feature: Filter Dimensions Private Endpoints Not Enabled
           },
           {
             "name": "geography",
+            "id": "city",
+            "label": "City",
             "options": [
               "Cardiff",
               "London",
@@ -109,6 +113,8 @@ Feature: Filter Dimensions Private Endpoints Not Enabled
       "items": [
         {
           "name": "geography",
+          "id": "city",
+          "label": "City",
           "links": {
             "filter": {
               "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1",
@@ -119,12 +125,14 @@ Feature: Filter Dimensions Private Endpoints Not Enabled
             },
             "self": {
               "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/geography",
-              "id": "geography"
+              "id": "city"
             }
           }
         },
         {
           "name": "siblings",
+          "id": "siblings_3",
+          "label": "Number of siblings (3 mappings)",
           "links": {
             "filter": {
               "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1",
@@ -135,7 +143,7 @@ Feature: Filter Dimensions Private Endpoints Not Enabled
             },
             "self": {
               "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/siblings",
-              "id": "siblings"
+              "id": "siblings_3"
             }
           }
         }
@@ -154,6 +162,8 @@ Feature: Filter Dimensions Private Endpoints Not Enabled
     """
     {
       "name": "geography",
+      "id": "city",
+      "label": "City",
       "is_area_type": true,
       "links": {
         "filter": {
@@ -165,7 +175,7 @@ Feature: Filter Dimensions Private Endpoints Not Enabled
         },
         "self": {
           "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/geography",
-          "id": "geography"
+          "id": "city"
         }
       }
     }
@@ -193,7 +203,9 @@ Feature: Filter Dimensions Private Endpoints Not Enabled
     Then I should receive the following JSON response:
     """
     {
+      "id": "siblings_3",
       "name": "siblings",
+      "label": "Number of siblings (3 mappings)",
       "links": {
         "filter": {
           "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1",
@@ -204,7 +216,7 @@ Feature: Filter Dimensions Private Endpoints Not Enabled
         },
         "self": {
           "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/siblings",
-          "id": "siblings"
+          "id": "siblings_3"
         }
       }
     }
@@ -226,7 +238,9 @@ Feature: Filter Dimensions Private Endpoints Not Enabled
     And I should receive the following JSON response:
     """
     {
+      "id": "siblings_3",
       "name": "siblings",
+      "label": "Number of siblings (3 mappings)",
       "links": {
         "filter": {
           "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1",
@@ -237,7 +251,7 @@ Feature: Filter Dimensions Private Endpoints Not Enabled
         },
         "self": {
           "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/siblings",
-          "id": "siblings"
+          "id": "siblings_3"
         }
       }
     }
@@ -329,6 +343,8 @@ Feature: Filter Dimensions Private Endpoints Not Enabled
       "items": [
         {
           "name": "geography",
+          "id": "city",
+          "label": "City",
           "links": {
             "filter": {
               "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1",
@@ -339,7 +355,7 @@ Feature: Filter Dimensions Private Endpoints Not Enabled
             },
             "self": {
               "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/geography",
-              "id": "geography"
+              "id": "city"
             }
           }
         }
@@ -360,6 +376,8 @@ Feature: Filter Dimensions Private Endpoints Not Enabled
       "items": [
         {
           "name": "siblings",
+          "id": "siblings_3",
+          "label": "Number of siblings (3 mappings)",
           "links": {
             "filter": {
               "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1",
@@ -370,7 +388,7 @@ Feature: Filter Dimensions Private Endpoints Not Enabled
             },
             "self": {
               "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/siblings",
-              "id": "siblings"
+              "id": "siblings_3"
             }
           }
         }

--- a/features/put_filters_dimensions.feature
+++ b/features/put_filters_dimensions.feature
@@ -244,9 +244,10 @@ Feature: Updating a filter's dimensions
       "total_count": 2
     }
     """
-    Then the document in the database for id "94310d8d-72d6-492a-bc30-27584627edb1" should match:
+    Then a document in collection "filters" with key "filter_id" value "94310d8d-72d6-492a-bc30-27584627edb1" should match:
     """
     {
+      "_id": "94310d8d-72d6-492a-bc30-27584627edb1",
       "filter_id": "94310d8d-72d6-492a-bc30-27584627edb1",
       "links": {
         "version": {
@@ -256,13 +257,18 @@ Feature: Updating a filter's dimensions
         "self": {
           "href": ":27100/filters/94310d8d-72d6-492a-bc30-27584627edb1"
         },
-        "dimensions": {}
+        "dimensions": {
+          "href": ""
+        }
       },
+      "etag": "b93d5717c0bb574bf989b5db3527c2f7d0a7abac",
       "instance_id": "c733977d-a2ca-4596-9cb1-08a6e724858b",
       "dataset": {
         "id": "cantabular-example-1",
         "edition": "2021",
-        "version": 1
+        "version": {
+          "$numberInt":"1"
+        }
       },
       "dimensions": [
         {
@@ -282,7 +288,18 @@ Feature: Updating a filter's dimensions
       ],
       "population_type": "Example",
       "published": true,
-      "type": "flexible"
+      "type": "flexible",
+      "unique_timestamp":{
+        "$timestamp":{
+          "i":1,
+          "t":1.643200024e+09
+        }
+      },
+      "last_updated":{
+        "$date":{
+          "$numberLong":"1643200024783"
+        }
+      }
     }
     """
 

--- a/features/put_filters_dimensions.feature
+++ b/features/put_filters_dimensions.feature
@@ -203,6 +203,8 @@ Feature: Updating a filter's dimensions
       "items": [
         {
           "name": "geography",
+          "id": "country",
+          "label": "Country",
           "links": {
             "filter": {
               "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1",
@@ -219,6 +221,8 @@ Feature: Updating a filter's dimensions
         },
         {
           "name": "siblings",
+          "id": "siblings_3",
+          "label": "Number of siblings (3 mappings)",
           "links": {
             "filter": {
               "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1",

--- a/features/put_filters_dimensions.feature
+++ b/features/put_filters_dimensions.feature
@@ -3,67 +3,67 @@ Feature: Updating a filter's dimensions
   Background:
     Given private endpoints are not enabled
     And the following version document with dataset id "cantabular-example-1", edition "2021" and version "1" is available from dp-dataset-api:
-      """
-       {
-        "alerts": [],
-        "collection_id": "dfb-38b11d6c4b69493a41028d10de503aabed3728828e17e64914832d91e1f493c6",
-        "dimensions": [
-          {
-            "label": "City",
-            "links": {
-              "code_list": {},
-              "options": {},
-              "version": {}
-            },
-            "href": "http://api.localhost:23200/v1/code-lists/city",
-            "id": "city",
-            "name": "City"
+    """
+    {
+      "alerts": [],
+      "collection_id": "dfb-38b11d6c4b69493a41028d10de503aabed3728828e17e64914832d91e1f493c6",
+      "dimensions": [
+        {
+          "name": "geography",
+          "id": "city",
+          "label": "City",
+          "links": {
+            "code_list": {},
+            "options": {},
+            "version": {}
           },
-          {
-            "label": "Country",
-            "links": {
-              "code_list": {},
-              "options": {},
-              "version": {}
-            },
-            "href": "http://api.localhost:23200/v1/code-lists/country",
-            "id": "country",
-            "name": "Country"
-          },
-          {
-            "label": "Number of siblings (3 mappings)",
-            "links": {
-              "code_list": {},
-              "options": {},
-              "version": {}
-            },
-            "href": "http://api.localhost:23200/v1/code-lists/siblings",
-            "id": "siblings",
-            "name": "Number of siblings (3 mappings)"
-          }
-        ],
-        "edition": "2021",
-        "id": "c733977d-a2ca-4596-9cb1-08a6e724858b",
-        "links": {
-          "dataset": {
-            "href": "http://dp-dataset-api:22000/datasets/cantabular-example-1",
-            "id": "cantabular-example-1"
-          },
-          "dimensions": {},
-          "edition": {
-            "href": "http://localhost:22000/datasets/cantabular-example-1/editions/2021",
-            "id": "2021"
-          },
-          "self": {
-            "href": "http://localhost:22000/datasets/cantabular-example-1/editions/2021/versions/1"
-          }
+          "href": "http://api.localhost:23200/v1/code-lists/city"
         },
-        "release_date": "2021-11-19T00:00:00.000Z",
-        "state": "published",
-        "usage_notes": [],
-        "version": 1
-      }
-      """
+        {
+          "name": "geography",
+          "id": "country",
+          "label": "Country",
+          "links": {
+            "code_list": {},
+            "options": {},
+            "version": {}
+          },
+          "href": "http://api.localhost:23200/v1/code-lists/country"
+        },
+        {
+          "id": "siblings_3",
+          "name": "siblings",
+          "label": "Number of siblings (3 mappings)",
+          "links": {
+            "code_list": {},
+            "options": {},
+            "version": {}
+          },
+          "href": "http://api.localhost:23200/v1/code-lists/siblings"
+        }
+      ],
+      "edition": "2021",
+      "id": "c733977d-a2ca-4596-9cb1-08a6e724858b",
+      "links": {
+        "dataset": {
+          "href": "http://dp-dataset-api:22000/datasets/cantabular-example-1",
+          "id": "cantabular-example-1"
+        },
+        "dimensions": {},
+        "edition": {
+          "href": "http://localhost:22000/datasets/cantabular-example-1/editions/2021",
+          "id": "2021"
+        },
+        "self": {
+          "href": "http://localhost:22000/datasets/cantabular-example-1/editions/2021/versions/1"
+        }
+      },
+      "release_date": "2021-11-19T00:00:00.000Z",
+      "state": "published",
+      "usage_notes": [],
+      "version": 1
+    }
+    """
     And I have this filter with an ETag of "city":
     """
     {
@@ -81,13 +81,17 @@ Feature: Updating a filter's dimensions
       "instance_id": "c733977d-a2ca-4596-9cb1-08a6e724858b",
       "dimensions": [
         {
-          "name": "Number of siblings (3 mappings)",
+          "name": "siblings",
+          "id": "siblings_3",
+          "label": "Number of siblings (3 mappings)",
           "options": [],
           "dimension_url": "http://dimension.url/siblings",
           "is_area_type": false
         },
         {
-          "name": "City",
+          "name": "geography",
+          "id": "city",
+          "label": "City",
           "options": [
             "London"
           ],
@@ -105,73 +109,77 @@ Feature: Updating a filter's dimensions
       "type": "flexible"
     }
     """
-    And Cantabular returns these dimensions for the dataset "Example" and search term "Country":
+    And Cantabular returns these dimensions for the dataset "Example" and search term "country":
     """
     {
       "dataset": {
-          "variables": {
-              "search": {
-                  "edges": [
-                      {
+        "variables": {
+          "search": {
+            "edges": [
+              {
+                "node": {
+                  "name": "country",
+                  "label": "Country",
+                  "mapFrom": [
+                    {
+                      "edges": [
+                        {
                           "node": {
-                              "name": "country",
-                              "label": "Country",
-                              "mapFrom": [
-                                  {
-                                      "edges": [
-                                          {
-                                              "node": {
-                                                  "label": "City",
-                                                  "name": "city"
-                                              }
-                                          }
-                                      ],
-                                      "totalCount": 1
-                                  }
-                              ]
+                            "label": "City",
+                            "name": "city"
                           }
-                      }
+                        }
+                      ],
+                      "totalCount": 1
+                    }
                   ]
+                }
               }
+            ]
           }
+        }
       }
     }
     """
 
   Scenario: Replacing a filter dimension (returns the dimension)
-    When I PUT "/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/City"
+    When I PUT "/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/geography"
     """
     {
-      "name": "Country",
+      "name": "geography",
+      "id": "country",
       "is_area_type": true
     }
     """
     Then I should receive the following JSON response:
     """
     {
-        "name": "Country",
-        "links": {
-          "filter": {
-            "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1",
-            "id": "94310d8d-72d6-492a-bc30-27584627edb1"
-          },
-          "options": {
-            "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/Country/options"
-          },
-          "self": {
-            "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/Country",
-            "id": "Country"
-          }
+      "name": "geography",
+      "id": "country",
+      "label": "Country",
+      "links": {
+        "filter": {
+          "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1",
+          "id": "94310d8d-72d6-492a-bc30-27584627edb1"
+        },
+        "options": {
+          "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/geography/options"
+        },
+        "self": {
+          "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/geography",
+          "id": "country"
         }
+      }
     }
     """
     And the HTTP status code should be "200"
 
   Scenario: Replacing a filter dimension (updates the ETag)
-    When I PUT "/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/City"
+    When I PUT "/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/geography"
     """
     {
-      "name": "Country",
+      "name": "geography",
+      "id": "country",
       "is_area_type": true
     }
     """
@@ -180,10 +188,11 @@ Feature: Updating a filter's dimensions
   # It would be good to also validate the options/area type bool were saved correctly, however the endpoint to
   # retrieve a dimension hasn't yet been implemented.
   Scenario: Replacing a filter dimension (updates the filter)
-    When I PUT "/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/City"
+    When I PUT "/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/geography"
     """
     {
-      "name": "Country",
+      "name": "geography",
+      "id": "country",
       "is_area_type": true
     }
     """
@@ -192,38 +201,38 @@ Feature: Updating a filter's dimensions
     """
     {
       "items": [
-          {
-              "name": "Country",
-              "links": {
-                "filter": {
-                  "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1",
-                  "id": "94310d8d-72d6-492a-bc30-27584627edb1"
-                },
-                "options": {
-                  "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/Country/options"
-                },
-                "self": {
-                  "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/Country",
-                  "id": "Country"
-                }
-              }
-          },
-          {
-              "name": "Number of siblings (3 mappings)",
-              "links": {
-                "filter": {
-                  "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1",
-                  "id": "94310d8d-72d6-492a-bc30-27584627edb1"
-                },
-                "options": {
-                  "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/Number of siblings (3 mappings)/options"
-                },
-                "self": {
-                  "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/Number of siblings (3 mappings)",
-                  "id": "Number of siblings (3 mappings)"
-                }
-              }
+        {
+          "name": "geography",
+          "links": {
+            "filter": {
+              "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1",
+              "id": "94310d8d-72d6-492a-bc30-27584627edb1"
+            },
+            "options": {
+              "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/geography/options"
+            },
+            "self": {
+              "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/geography",
+              "id": "country"
+            }
           }
+        },
+        {
+          "name": "siblings",
+          "links": {
+            "filter": {
+              "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1",
+              "id": "94310d8d-72d6-492a-bc30-27584627edb1"
+            },
+            "options": {
+              "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/siblings/options"
+            },
+            "self": {
+              "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/siblings",
+              "id": "siblings_3"
+            }
+          }
+        }
       ],
       "limit": 20,
       "offset": 0,
@@ -231,22 +240,63 @@ Feature: Updating a filter's dimensions
       "total_count": 2
     }
     """
-
-  Scenario: An invalid JSON body (results in a 400 status code)
-    When I PUT "/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/City"
+    Then the document in the database for id "94310d8d-72d6-492a-bc30-27584627edb1" should match:
     """
     {
-      "name": "Country
+      "filter_id": "94310d8d-72d6-492a-bc30-27584627edb1",
+      "links": {
+        "version": {
+          "href": "http://mockhost:9999/datasets/cantabular-example-1/editions/2021/version/1",
+          "id": "1"
+        },
+        "self": {
+          "href": ":27100/filters/94310d8d-72d6-492a-bc30-27584627edb1"
+        },
+        "dimensions": {}
+      },
+      "instance_id": "c733977d-a2ca-4596-9cb1-08a6e724858b",
+      "dataset": {
+        "id": "cantabular-example-1",
+        "edition": "2021",
+        "version": 1
+      },
+      "dimensions": [
+        {
+          "name": "siblings",
+          "id": "siblings_3",
+          "label": "Number of siblings (3 mappings)",
+          "options": [],
+          "is_area_type": false
+        },
+        {
+          "name": "geography",
+          "id": "country",
+          "label": "Country",
+          "options": [],
+          "is_area_type": true
+        }
+      ],
+      "population_type": "Example",
+      "published": true,
+      "type": "flexible"
+    }
+    """
+
+  Scenario: An invalid JSON body (results in a 400 status code)
+    When I PUT "/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/geography"
+    """
+    {
+      "name": "country
     }
     """
     Then I should receive an errors array
     And the HTTP status code should be "400"
 
   Scenario: An invalid JSON body (doesn't update the filter)
-    When I PUT "/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/City"
+    When I PUT "/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/geography"
     """
     {
-      "name": "Country
+      "name": "country
     }
     """
     And I GET "/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions"
@@ -254,38 +304,42 @@ Feature: Updating a filter's dimensions
     """
     {
       "items": [
-          {
-              "name": "City",
-              "links": {
-                "filter": {
-                  "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1",
-                  "id": "94310d8d-72d6-492a-bc30-27584627edb1"
-                },
-                "options": {
-                  "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/City/options"
-                },
-                "self": {
-                  "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/City",
-                  "id": "City"
-                }
-              }
-          },
-          {
-              "name": "Number of siblings (3 mappings)",
-              "links": {
-                "filter": {
-                  "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1",
-                  "id": "94310d8d-72d6-492a-bc30-27584627edb1"
-                },
-                "options": {
-                  "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/Number of siblings (3 mappings)/options"
-                },
-                "self": {
-                  "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/Number of siblings (3 mappings)",
-                  "id": "Number of siblings (3 mappings)"
-                }
-              }
+        {
+          "name": "geography",
+          "id": "city",
+          "label": "City",
+          "links": {
+            "filter": {
+              "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1",
+              "id": "94310d8d-72d6-492a-bc30-27584627edb1"
+            },
+            "options": {
+              "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/geography/options"
+            },
+            "self": {
+              "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/geography",
+              "id": "city"
+            }
           }
+        },
+        {
+          "name": "siblings",
+          "id": "siblings_3",
+          "label": "Number of siblings (3 mappings)",
+          "links": {
+            "filter": {
+              "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1",
+              "id": "94310d8d-72d6-492a-bc30-27584627edb1"
+            },
+            "options": {
+              "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/siblings/options"
+            },
+            "self": {
+              "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/siblings",
+              "id": "siblings_3"
+            }
+          }
+        }
       ],
       "limit": 20,
       "offset": 0,
@@ -296,10 +350,11 @@ Feature: Updating a filter's dimensions
 
   Scenario: An If-Match header is provided and doesn't match (returns a 409 status code)
     When I set the "If-Match" header to "stale"
-    And I PUT "/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/City"
+    And I PUT "/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/geography"
     """
     {
-      "name": "Country",
+      "name": "geography",
+      "id": "country",
       "is_area_type": true
     }
     """
@@ -308,10 +363,11 @@ Feature: Updating a filter's dimensions
 
   Scenario: An If-Match header is provided and doesn't match (doesn't update the filter)
     When I set the "If-Match" header to "stale"
-    And I PUT "/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/City"
+    And I PUT "/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/geography"
     """
     {
-      "name": "Country",
+      "name": "geography",
+      "id": "country",
       "is_area_type": true
     }
     """
@@ -320,38 +376,42 @@ Feature: Updating a filter's dimensions
     """
     {
       "items": [
-          {
-              "name": "City",
-              "links": {
-                "filter": {
-                  "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1",
-                  "id": "94310d8d-72d6-492a-bc30-27584627edb1"
-                },
-                "options": {
-                  "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/City/options"
-                },
-                "self": {
-                  "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/City",
-                  "id": "City"
-                }
-              }
-          },
-          {
-              "name": "Number of siblings (3 mappings)",
-              "links": {
-                "filter": {
-                  "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1",
-                  "id": "94310d8d-72d6-492a-bc30-27584627edb1"
-                },
-                "options": {
-                  "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/Number of siblings (3 mappings)/options"
-                },
-                "self": {
-                  "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/Number of siblings (3 mappings)",
-                  "id": "Number of siblings (3 mappings)"
-                }
-              }
+        {
+          "name": "geography",
+          "id": "city",
+          "label": "City",
+          "links": {
+            "filter": {
+              "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1",
+              "id": "94310d8d-72d6-492a-bc30-27584627edb1"
+            },
+            "options": {
+              "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/geography/options"
+            },
+            "self": {
+              "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/geography",
+              "id": "city"
+            }
           }
+        },
+        {
+          "name": "siblings",
+          "id": "siblings_3",
+          "label": "Number of siblings (3 mappings)",
+          "links": {
+            "filter": {
+              "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1",
+              "id": "94310d8d-72d6-492a-bc30-27584627edb1"
+            },
+            "options": {
+              "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/siblings/options"
+            },
+            "self": {
+              "href": "http://localhost:22100/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/siblings",
+              "id": "siblings_3"
+            }
+          }
+        }
       ],
       "limit": 20,
       "offset": 0,
@@ -361,10 +421,11 @@ Feature: Updating a filter's dimensions
     """
 
   Scenario: The filter doesn't exist in the database
-    When I PUT "/filters/not-found/dimensions/City"
+    When I PUT "/filters/not-found/dimensions/geography"
     """
     {
-      "name": "Country",
+      "name": "geography",
+      "id": "country",
       "is_area_type": true
     }
     """
@@ -372,10 +433,11 @@ Feature: Updating a filter's dimensions
     And the HTTP status code should be "400"
 
   Scenario: The dimension doesn't exist in the database
-    When I PUT "/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/Sex"
+    When I PUT "/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/sex"
     """
     {
-      "name": "Country",
+      "name": "geography",
+      "id": "country",
       "is_area_type": true
     }
     """
@@ -383,10 +445,11 @@ Feature: Updating a filter's dimensions
     Then the HTTP status code should be "404"
 
   Scenario: The dimension doesn't exist in Cantabular
-    When I PUT "/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/City"
+    When I PUT "/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/geography"
     """
     {
-      "name": "Fake",
+      "name": "geography",
+      "id": "fake",
       "is_area_type": false
     }
     """
@@ -395,10 +458,11 @@ Feature: Updating a filter's dimensions
 
   Scenario: Searching Cantabular results in an error
     When Cantabular responds with an error
-    And I PUT "/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/City"
+    And I PUT "/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions/geography"
     """
     {
-      "name": "Country",
+      "id": "country",
+      "name": "geography",
       "is_area_type": true
     }
     """

--- a/features/steps/steps.go
+++ b/features/steps/steps.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"reflect"
 	"time"
 
 	"github.com/ONSdigital/dp-api-clients-go/v2/cantabular"
@@ -19,6 +20,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rdumont/assistdog"
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 func (c *Component) RegisterSteps(ctx *godog.ScenarioContext) {
@@ -39,8 +41,8 @@ func (c *Component) RegisterSteps(ctx *godog.ScenarioContext) {
 		c.theMaximumLimitIsSetTo,
 	)
 	ctx.Step(
-		`^the document in the database for id "([^"]*)" should be:$`,
-		c.theDocumentInTheDatabaseShouldBe,
+		`^the document in the database for id "([^"]*)" should match:$`,
+		c.theDocumentInTheDatabaseShouldMatch,
 	)
 	ctx.Step(
 		`^the following version document with dataset id "([^"]*)", edition "([^"]*)" and version "([^"]*)" is available from dp-dataset-api:$`,
@@ -273,9 +275,32 @@ func (c *Component) privateEndpointsAreNotEnabled() error {
 	return nil
 }
 
-func (c *Component) theDocumentInTheDatabaseShouldBe(id string, doc *godog.DocString) error {
-	// TODO: implement step for verifying documents stored in Mongo. No prior
-	// art of this being done properly in ONS yet so save to be done in future ticket
+// theDocumentInTheDatabaseShouldMatch checks if the filter in the DB matches the one provided.
+// Timestamps and the ETag are ignored.
+func (c *Component) theDocumentInTheDatabaseShouldMatch(fID string, doc *godog.DocString) error {
+	var expFilter model.Filter
+	if err := json.Unmarshal([]byte(doc.Content), &expFilter); err != nil {
+		return errors.Wrap(err, "failed to unmarshall")
+	}
+
+	ctx := context.Background()
+	col := c.cfg.FiltersCollection
+
+	var response model.Filter
+	if err := c.store.Conn().Collection(col).FindOne(ctx, bson.M{"filter_id": fID}, &response); err != nil {
+		return errors.Wrap(err, "failed to retrieve filter")
+	}
+
+	// ETags are compared by a separate assertion
+	response.ETag = ""
+	// Don't compare time, since it will be non-deterministic
+	response.LastUpdated = time.Time{}
+	response.UniqueTimestamp = primitive.Timestamp{}
+
+	if !reflect.DeepEqual(expFilter, response) {
+		return fmt.Errorf("Document did not match\nExpected:\n%+v\nGot:\n%+v\n", expFilter, response)
+	}
+
 	return nil
 }
 

--- a/model/filter.go
+++ b/model/filter.go
@@ -71,9 +71,11 @@ type Event struct {
 }
 
 type Dimension struct {
-	Name         string   `bson:"name"          json:"name"`
-	Options      []string `bson:"options"       json:"options"`
-	IsAreaType   bool     `bson:"is_area_type"  json:"is_area_type"`
+	Name       string   `bson:"name"          json:"name"`
+	ID         string   `bson:"id"            json:"id"`
+	Label      string   `bson:"label"         json:"label"`
+	Options    []string `bson:"options"       json:"options"`
+	IsAreaType bool     `bson:"is_area_type"  json:"is_area_type"`
 }
 
 type Dataset struct {

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -103,6 +103,13 @@ parameters:
     required: true
     description: A dimension to filter the dataset
     in: body
+  dimensionUpdate:
+    name: dimension
+    schema:
+      $ref: '#/definitions/DimensionUpdate'
+    required: true
+    description: A dimension to update on the filter
+    in: body
   patch_options:
     required: true
     name: patch
@@ -360,7 +367,7 @@ paths:
       summary: "Update a dimension"
       description: "Update the filter by updating a selected dimension"
       parameters:
-      - $ref: '#/parameters/dimension'
+      - $ref: '#/parameters/dimensionUpdate'
       - $ref: '#/parameters/if_match'
       responses:
         200:
@@ -638,6 +645,22 @@ definitions:
       name:
         type: string
         description: "The name of the dimension to filter on"
+      is_area_type:
+        type: boolean
+        description: Indicates if the dimension is an area type
+      options:
+        type: array
+        items:
+          type: string
+  DimensionUpdate:
+    type: object
+    description: "A dimension to update on a dataset."
+    required:
+      - id
+    properties:
+      id:
+        type: string
+        example: city
       is_area_type:
         type: boolean
         description: Indicates if the dimension is an area type
@@ -991,6 +1014,10 @@ definitions:
   DimensionItem:
     properties:
       name:
+        type: string
+      id:
+        type: string
+      label:
         type: string
       links:
         $ref: "#/definitions/DimensionItemLinks"


### PR DESCRIPTION
### What

![2022-04-21 at 11 07 06](https://user-images.githubusercontent.com/3719745/164432472-3be8258b-9a2a-404a-aeed-3720145d211f.png)

Now stores two additional fields on a filter dimensions: ID and label.

Previously we assumed that the `name` field on a filter was sufficient, since it would contain the selection for a dimension (e.g. `name: "city"`). Our new understanding is that the underlying name should remain unchanged (e.g. consistently `name: "geography"`), which means that we also need to store the currently selected choice (`id`). The label is included as a convenience for the frontend and any other consumers.

This is one step towards [5664](https://trello.com/c/3TbBPTvY), and will enable the frontend to query for/update a specific filter dimension using a consistent machine-readable name (once the import process has also been updated).

### How to review

Ensure the change makes sense, both conceptually/schema wise and in implementation.

### Who can review

Anyone, but probably Team B.
