### PR TITLE
Stop passing a reference to event.ExportStart

### DIFF
--- a/api/events.go
+++ b/api/events.go
@@ -8,7 +8,7 @@ import (
 )
 
 // ProduceCSVCreateEvent creates an event to create a csv when POST filters/{id}/submit is hit
-func (api *API) produceExportStartEvent(e *event.ExportStart) error {
+func (api *API) produceExportStartEvent(e event.ExportStart) error {
 	if err := api.producer.Send(schema.ExportStart, e); err != nil {
 		return errors.Wrap(err, "error sending 'export_start' event")
 	}

--- a/api/filters.go
+++ b/api/filters.go
@@ -189,7 +189,7 @@ func (api *API) submitFilter(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// send the export event through Kafka
-	if err := api.produceExportStartEvent(&e); err != nil {
+	if err := api.produceExportStartEvent(e); err != nil {
 		api.respond.Error(
 			ctx,
 			w,


### PR DESCRIPTION
### What

There is no need to pass a pointer/reference.
A copy will suffice and is more efficient for such a small struct.

### How to review

This PR

### Who can review

Anyone.
