### PR TITLE
allow public or private to be empty when updating filter ouput downloads

### DIFF
--- a/features/put_filter_outputs.feature
+++ b/features/put_filter_outputs.feature
@@ -480,7 +480,7 @@ Feature: Put Filter Outputs Private Endpoints Not Enabled
             "txt":
             {
               "href": "http://localhost:23600/downloads/datasets/cantabular-flexible-example/editions/2021/versions/1.txt",
-              "private": "http://minio:9000/private-bucket/datasets/cantabular-flexible-example-2021-1.txt",
+              "private": "",
               "public": "",
               "size": "530",
               "skipped": true
@@ -493,7 +493,7 @@ Feature: Put Filter Outputs Private Endpoints Not Enabled
     """
     {
       "errors": [
-        "invalid request body: invalid request: 'txt' field not fully populated: \"public\" is empty in input"
+        "invalid request body: invalid request: 'txt' field not fully populated: \"public\" or \"private\" must be populated"
       ]
     }
     """

--- a/model/filter.go
+++ b/model/filter.go
@@ -87,12 +87,8 @@ func (fi *FileInfo) IsNotFullyPopulated() error {
 		return errors.New(`"HREF" is empty in input`)
 	}
 
-	if len(strings.Trim(fi.Private, cutset)) == 0 {
-		return errors.New(`"private" is empty in input`)
-	}
-
-	if len(strings.Trim(fi.Public, cutset)) == 0 {
-		return errors.New(`"public" is empty in input`)
+	if len(strings.Trim(fi.Private, cutset)) == 0 && len(strings.Trim(fi.Public, cutset)) == 0 {
+		return errors.New(`"public" or "private" must be populated`)
 	}
 
 	if len(strings.Trim(fi.Size, cutset)) == 0 {


### PR DESCRIPTION
### What

Updated validation for updating filter outputs to allow 'public' and 'private' fields to be updated individually.

### How to review

Check change makes sense

### Who can review

Anyone