### PR TITLE
break down api/filters.go separate file for dimensions

### DIFF
--- a/api/filter_dimension_options.go
+++ b/api/filter_dimension_options.go
@@ -1,0 +1,1 @@
+package api

--- a/api/filter_dimensions.go
+++ b/api/filter_dimensions.go
@@ -1,0 +1,372 @@
+package api
+
+import (
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	dperrors "github.com/ONSdigital/dp-cantabular-filter-flex-api/errors"
+	"github.com/ONSdigital/dp-cantabular-filter-flex-api/model"
+	dprequest "github.com/ONSdigital/dp-net/v2/request"
+	"github.com/ONSdigital/log.go/v2/log"
+	"github.com/go-chi/chi/v5"
+	"github.com/pkg/errors"
+)
+
+func (api *API) addFilterDimension(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	fID := chi.URLParam(r, "id")
+
+	var req addFilterDimensionRequest
+
+	if err := api.ParseRequest(r.Body, &req); err != nil {
+		api.respond.Error(
+			ctx,
+			w,
+			http.StatusBadRequest,
+			errors.Wrap(err, "failed to parse request"),
+		)
+		return
+	}
+
+	logData := log.Data{
+		"request": req,
+		"id":      fID,
+	}
+
+	filter, err := api.store.GetFilter(ctx, fID)
+	if err != nil {
+		api.respond.Error(
+			ctx,
+			w,
+			statusCode(err),
+			Error{
+				err:     errors.Wrap(err, "failed to get filter"),
+				message: "failed to get filter",
+				logData: logData,
+			},
+		)
+		return
+	}
+
+	v, err := api.datasets.GetVersion(
+		ctx,
+		"",
+		api.cfg.ServiceAuthToken,
+		"",
+		"",
+		filter.Dataset.ID,
+		filter.Dataset.Edition,
+		strconv.Itoa(filter.Dataset.Version),
+	)
+	if err != nil {
+		api.respond.Error(
+			ctx,
+			w,
+			statusCode(err),
+			Error{
+				err:     errors.Wrap(err, "failed to get existing Version"),
+				message: "failed to get existing dataset information",
+				logData: logData,
+			},
+		)
+		return
+	}
+
+	if v.State != published && !dprequest.IsCallerPresent(ctx) {
+		api.respond.Error(
+			ctx,
+			w,
+			http.StatusNotFound,
+			Error{
+				err:     errors.New("unauthenticated request on unpublished dataset"),
+				message: "dataset not found",
+				logData: logData,
+			},
+		)
+		return
+	}
+
+	if err := api.isValidDatasetDimensions(ctx, v, []model.Dimension{req.Dimension}, filter.PopulationType); err != nil {
+		api.respond.Error(ctx, w, statusCode(err), err)
+		return
+	}
+
+	h, err := filter.HashDimensions()
+	if err != nil {
+		api.respond.Error(
+			ctx,
+			w,
+			http.StatusInternalServerError,
+			Error{
+				err:     errors.Wrap(err, "failed to hash existing filter dimensions"),
+				logData: logData,
+			},
+		)
+		return
+	}
+
+	if eTag := api.getETag(r); eTag != eTagAny && !strings.Contains(eTag, h) {
+		api.respond.Error(
+			ctx,
+			w,
+			http.StatusConflict,
+			Error{
+				err:     errors.Wrap(err, "ETag does not match"),
+				logData: logData,
+			},
+		)
+		return
+	}
+
+	dim := hydrateDimensions([]model.Dimension{req.Dimension}, v.Dimensions)[0]
+
+	if err := api.store.AddFilterDimension(ctx, fID, dim); err != nil {
+		api.respond.Error(
+			ctx,
+			w,
+			statusCode(err),
+			Error{
+				err:     errors.Wrap(err, "failed to add filter dimension"),
+				logData: logData,
+			},
+		)
+		return
+	}
+
+	filter, err = api.store.GetFilter(ctx, fID)
+	if err != nil {
+		api.respond.Error(
+			ctx,
+			w,
+			statusCode(err),
+			Error{
+				err:     errors.Wrap(err, "failed to get updated filter"),
+				message: "failed to get updated filter",
+				logData: logData,
+			},
+		)
+		return
+	}
+
+	b, err := filter.HashDimensions()
+	if err != nil {
+		api.respond.Error(
+			ctx,
+			w,
+			http.StatusInternalServerError,
+			Error{
+				err:     errors.Wrap(err, "failed to hash filter dimensions"),
+				logData: logData,
+			},
+		)
+		return
+	}
+
+	var resp addFilterDimensionResponse
+	resp.dimensionItem.fromDimension(
+		dim,
+		api.cfg.FilterAPIURL,
+		fID,
+	)
+
+	w.Header().Set(eTagHeader, b)
+	api.respond.JSON(ctx, w, http.StatusCreated, resp)
+}
+
+func (api *API) updateFilterDimension(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	filterID := chi.URLParam(r, "id")
+	dimensionName := chi.URLParam(r, "name")
+
+	logData := log.Data{
+		"filter_id":      filterID,
+		"dimension_name": dimensionName,
+	}
+
+	req := updateFilterDimensionRequest{
+		Dimension: model.Dimension{
+			Name:    dimensionName,
+			Options: []string{},
+		},
+	}
+
+	if err := api.ParseRequest(r.Body, &req); err != nil {
+		api.respond.Error(
+			ctx,
+			w,
+			http.StatusBadRequest,
+			Error{
+				err:     errors.Wrap(err, "failed to parse update filter request"),
+				logData: logData,
+			},
+		)
+		return
+	}
+
+	// The new dimension won't be present on the dataset (i.e. only `City` will be present, not `Country`),
+	// so instead of validating it against the existing Version, we check to see if the dimension exists in Cantabular.
+	node, err := api.getCantabularDimension(ctx, filterID, req.ID)
+	if err != nil {
+		api.respond.Error(
+			ctx,
+			w,
+			statusCode(err),
+			Error{
+				err:     errors.Wrap(err, "error searching for dimension"),
+				logData: logData,
+			},
+		)
+		return
+	}
+
+	// ID/name is provided by the request, but the label is provided by Cantabular.
+	req.Label = node.Label
+
+	var eTag string
+	if reqETag := api.getETag(r); reqETag != eTagAny {
+		eTag = reqETag
+	}
+
+	newETag, err := api.store.UpdateFilterDimension(ctx, filterID, dimensionName, req.Dimension, eTag)
+	if err != nil {
+		api.respond.Error(
+			ctx,
+			w,
+			statusCode(err),
+			Error{
+				err:     errors.Wrap(err, "unable to update filter dimension"),
+				logData: logData,
+			},
+		)
+		return
+	}
+
+	resp := updateFilterDimensionResponse{}
+	resp.fromDimension(req.Dimension, api.cfg.FilterAPIURL, filterID)
+
+	w.Header().Set(eTagHeader, newETag)
+
+	api.respond.JSON(ctx, w, http.StatusOK, resp)
+}
+
+func (api *API) getFilterDimension(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	fID := chi.URLParam(r, "id")
+	dim := chi.URLParam(r, "dimension")
+
+	logData := log.Data{
+		"id":        fID,
+		"dimension": dim,
+	}
+
+	// We decode the dimension name since currently dimensions are stored using their pretty name, e.g.
+	// `Number of Siblings`, and passed in the URL as encoded (e.g. `Number+of+Siblings`). Until this is
+	// changed we need to unescape the dimension before querying.
+	dimName, err := url.QueryUnescape(dim)
+	if err != nil {
+		api.respond.Error(
+			ctx,
+			w,
+			statusCode(err),
+			Error{
+				err:     errors.Wrap(err, "failed to decode dimension name"),
+				message: "failed to decode dimension name",
+				logData: logData,
+			},
+		)
+		return
+	}
+
+	// Check the filter exists, so we can return a different status code
+	// from if the dimension doesn't exist.
+	if _, err := api.store.GetFilter(ctx, fID); err != nil {
+		status := statusCode(err)
+		if dperrors.NotFound(err) {
+			status = http.StatusBadRequest
+		}
+
+		api.respond.Error(
+			ctx,
+			w,
+			status,
+			Error{
+				err:     errors.Wrap(err, "failed to get filter from store"),
+				message: "failed to get filter",
+				logData: logData,
+			},
+		)
+		return
+	}
+
+	filterDim, err := api.store.GetFilterDimension(ctx, fID, dimName)
+	if err != nil {
+		api.respond.Error(
+			ctx,
+			w,
+			statusCode(err),
+			Error{
+				err:     errors.Wrap(err, "failed to get filter dimension from store"),
+				message: "failed to get filter dimension",
+				logData: logData,
+			},
+		)
+		return
+	}
+
+	var resp getFilterDimensionResponse
+	resp.dimensionItem.fromDimension(filterDim, api.cfg.FilterAPIURL, fID)
+	resp.IsAreaType = filterDim.IsAreaType
+
+	api.respond.JSON(ctx, w, http.StatusOK, resp)
+}
+
+func (api *API) getFilterDimensions(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	fID := chi.URLParam(r, "id")
+
+	logData := log.Data{"id": fID}
+
+	limit, offset, err := getPaginationParams(r.URL, api.cfg.DefaultMaximumLimit)
+	if err != nil {
+		api.respond.Error(ctx, w, http.StatusBadRequest, &Error{
+			err:     err,
+			logData: logData,
+		})
+		return
+	}
+
+	logData["limit"] = limit
+	logData["offset"] = offset
+
+	dims, totalCount, err := api.store.GetFilterDimensions(ctx, fID, limit, offset)
+	if err != nil {
+		api.respond.Error(
+			ctx,
+			w,
+			statusCode(err),
+			Error{
+				err:     errors.Wrap(err, "failed to get filter dimensions"),
+				message: "failed to get filter dimensions",
+				logData: logData,
+			},
+		)
+		return
+	}
+
+	var items dimensionItems
+	items.fromDimensions(dims, api.cfg.FilterAPIURL, fID)
+
+	resp := getFilterDimensionsResponse{
+		Items: items,
+		paginationResponse: paginationResponse{
+			Limit:      limit,
+			Offset:     offset,
+			Count:      len(dims),
+			TotalCount: totalCount,
+		},
+	}
+
+	api.respond.JSON(ctx, w, http.StatusOK, resp)
+}

--- a/api/filters.go
+++ b/api/filters.go
@@ -3,14 +3,11 @@ package api
 import (
 	"context"
 	"net/http"
-	"net/url"
 	"strconv"
-	"strings"
 
 	"github.com/ONSdigital/dp-api-clients-go/v2/cantabular"
 	"github.com/ONSdigital/dp-api-clients-go/v2/cantabular/gql"
 	"github.com/ONSdigital/dp-api-clients-go/v2/dataset"
-	dperrors "github.com/ONSdigital/dp-cantabular-filter-flex-api/errors"
 	"github.com/ONSdigital/dp-cantabular-filter-flex-api/event"
 	"github.com/ONSdigital/dp-cantabular-filter-flex-api/model"
 	dprequest "github.com/ONSdigital/dp-net/v2/request"
@@ -67,7 +64,22 @@ func (api *API) createFilter(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !api.isValidDatasetDimensions(w, ctx, logData, v, req.Dimensions, req.PopulationType) {
+	if v.State != published && !dprequest.IsCallerPresent(ctx) {
+		api.respond.Error(
+			ctx,
+			w,
+			http.StatusNotFound,
+			Error{
+				err:     errors.New("unauthenticated request on unpublished dataset"),
+				message: "dataset not found",
+				logData: logData,
+			},
+		)
+		return
+	}
+
+	if err := api.isValidDatasetDimensions(ctx, v, req.Dimensions, req.PopulationType); err != nil {
+		api.respond.Error(ctx, w, statusCode(err), err)
 		return
 	}
 
@@ -286,228 +298,6 @@ func (api *API) getFilter(w http.ResponseWriter, r *http.Request) {
 	api.respond.JSON(ctx, w, http.StatusOK, resp)
 }
 
-func (api *API) addFilterDimension(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-	fID := chi.URLParam(r, "id")
-
-	var req addFilterDimensionRequest
-
-	if err := api.ParseRequest(r.Body, &req); err != nil {
-		api.respond.Error(
-			ctx,
-			w,
-			http.StatusBadRequest,
-			errors.Wrap(err, "failed to parse request"),
-		)
-		return
-	}
-
-	logData := log.Data{
-		"request": req,
-		"id":      fID,
-	}
-
-	filter, err := api.store.GetFilter(ctx, fID)
-	if err != nil {
-		api.respond.Error(
-			ctx,
-			w,
-			statusCode(err),
-			Error{
-				err:     errors.Wrap(err, "failed to get filter"),
-				message: "failed to get filter",
-				logData: logData,
-			},
-		)
-		return
-	}
-
-	v, err := api.datasets.GetVersion(
-		ctx,
-		"",
-		api.cfg.ServiceAuthToken,
-		"",
-		"",
-		filter.Dataset.ID,
-		filter.Dataset.Edition,
-		strconv.Itoa(filter.Dataset.Version),
-	)
-	if err != nil {
-		api.respond.Error(
-			ctx,
-			w,
-			statusCode(err),
-			Error{
-				err:     errors.Wrap(err, "failed to get existing Version"),
-				message: "failed to get existing dataset information",
-				logData: logData,
-			},
-		)
-		return
-	}
-
-	if !api.isValidDatasetDimensions(w, ctx, logData, v, []model.Dimension{req.Dimension}, filter.PopulationType) {
-		return
-	}
-
-	h, err := filter.HashDimensions()
-	if err != nil {
-		api.respond.Error(
-			ctx,
-			w,
-			http.StatusInternalServerError,
-			Error{
-				err:     errors.Wrap(err, "failed to hash existing filter dimensions"),
-				logData: logData,
-			},
-		)
-		return
-	}
-
-	if eTag := api.getETag(r); eTag != eTagAny && !strings.Contains(eTag, h) {
-		api.respond.Error(
-			ctx,
-			w,
-			http.StatusConflict,
-			Error{
-				err:     errors.Wrap(err, "ETag does not match"),
-				logData: logData,
-			},
-		)
-		return
-	}
-
-	dim := hydrateDimensions([]model.Dimension{req.Dimension}, v.Dimensions)[0]
-
-	if err := api.store.AddFilterDimension(ctx, fID, dim); err != nil {
-		api.respond.Error(
-			ctx,
-			w,
-			statusCode(err),
-			Error{
-				err:     errors.Wrap(err, "failed to add filter dimension"),
-				logData: logData,
-			},
-		)
-		return
-	}
-
-	filter, err = api.store.GetFilter(ctx, fID)
-	if err != nil {
-		api.respond.Error(
-			ctx,
-			w,
-			statusCode(err),
-			Error{
-				err:     errors.Wrap(err, "failed to get updated filter"),
-				message: "failed to get updated filter",
-				logData: logData,
-			},
-		)
-		return
-	}
-
-	b, err := filter.HashDimensions()
-	if err != nil {
-		api.respond.Error(
-			ctx,
-			w,
-			http.StatusInternalServerError,
-			Error{
-				err:     errors.Wrap(err, "failed to hash filter dimensions"),
-				logData: logData,
-			},
-		)
-		return
-	}
-
-	var resp addFilterDimensionResponse
-	resp.dimensionItem.fromDimension(
-		dim,
-		api.cfg.FilterAPIURL,
-		fID,
-	)
-
-	w.Header().Set(eTagHeader, b)
-	api.respond.JSON(ctx, w, http.StatusCreated, resp)
-}
-
-func (api *API) updateFilterDimension(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-	filterID := chi.URLParam(r, "id")
-	dimensionName := chi.URLParam(r, "name")
-
-	logData := log.Data{
-		"filter_id":      filterID,
-		"dimension_name": dimensionName,
-	}
-
-	req := updateFilterDimensionRequest{
-		Dimension: model.Dimension{
-			Name:    dimensionName,
-			Options: []string{},
-		},
-	}
-
-	if err := api.ParseRequest(r.Body, &req); err != nil {
-		api.respond.Error(
-			ctx,
-			w,
-			http.StatusBadRequest,
-			Error{
-				err:     errors.Wrap(err, "failed to parse update filter request"),
-				logData: logData,
-			},
-		)
-		return
-	}
-
-	// The new dimension won't be present on the dataset (i.e. only `City` will be present, not `Country`),
-	// so instead of validating it against the existing Version, we check to see if the dimension exists in Cantabular.
-	node, err := api.getCantabularDimension(ctx, filterID, req.ID)
-	if err != nil {
-		api.respond.Error(
-			ctx,
-			w,
-			statusCode(err),
-			Error{
-				err:     errors.Wrap(err, "error searching for dimension"),
-				logData: logData,
-			},
-		)
-		return
-	}
-
-	// ID/name is provided by the request, but the label is provided by Cantabular.
-	req.Label = node.Label
-
-	var eTag string
-	if reqETag := api.getETag(r); reqETag != eTagAny {
-		eTag = reqETag
-	}
-
-	newETag, err := api.store.UpdateFilterDimension(ctx, filterID, dimensionName, req.Dimension, eTag)
-	if err != nil {
-		api.respond.Error(
-			ctx,
-			w,
-			statusCode(err),
-			Error{
-				err:     errors.Wrap(err, "unable to update filter dimension"),
-				logData: logData,
-			},
-		)
-		return
-	}
-
-	resp := updateFilterDimensionResponse{}
-	resp.fromDimension(req.Dimension, api.cfg.FilterAPIURL, filterID)
-
-	w.Header().Set(eTagHeader, newETag)
-
-	api.respond.JSON(ctx, w, http.StatusOK, resp)
-}
-
 func (api *API) putFilter(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
@@ -529,171 +319,20 @@ func (api *API) putFilter(w http.ResponseWriter, r *http.Request) {
 	api.respond.JSON(ctx, w, http.StatusOK, resp)
 }
 
-func (api *API) getFilterDimensions(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-	fID := chi.URLParam(r, "id")
-
-	logData := log.Data{"id": fID}
-
-	limit, offset, err := getPaginationParams(r.URL, api.cfg.DefaultMaximumLimit)
-	if err != nil {
-		api.respond.Error(ctx, w, http.StatusBadRequest, &Error{
-			err:     err,
-			logData: logData,
-		})
-		return
-	}
-
-	logData["limit"] = limit
-	logData["offset"] = offset
-
-	dims, totalCount, err := api.store.GetFilterDimensions(ctx, fID, limit, offset)
-	if err != nil {
-		api.respond.Error(
-			ctx,
-			w,
-			statusCode(err),
-			Error{
-				err:     errors.Wrap(err, "failed to get filter dimensions"),
-				message: "failed to get filter dimensions",
-				logData: logData,
-			},
-		)
-		return
-	}
-
-	var items dimensionItems
-	items.fromDimensions(dims, api.cfg.FilterAPIURL, fID)
-
-	resp := getFilterDimensionsResponse{
-		Items: items,
-		paginationResponse: paginationResponse{
-			Limit:      limit,
-			Offset:     offset,
-			Count:      len(dims),
-			TotalCount: totalCount,
-		},
-	}
-
-	api.respond.JSON(ctx, w, http.StatusOK, resp)
-}
-
-func (api *API) getFilterDimension(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-	fID := chi.URLParam(r, "id")
-	dim := chi.URLParam(r, "dimension")
-
-	logData := log.Data{
-		"id":        fID,
-		"dimension": dim,
-	}
-
-	// We decode the dimension name since currently dimensions are stored using their pretty name, e.g.
-	// `Number of Siblings`, and passed in the URL as encoded (e.g. `Number+of+Siblings`). Until this is
-	// changed we need to unescape the dimension before querying.
-	dimName, err := url.QueryUnescape(dim)
-	if err != nil {
-		api.respond.Error(
-			ctx,
-			w,
-			statusCode(err),
-			Error{
-				err:     errors.Wrap(err, "failed to decode dimension name"),
-				message: "failed to decode dimension name",
-				logData: logData,
-			},
-		)
-		return
-	}
-
-	// Check the filter exists, so we can return a different status code
-	// from if the dimension doesn't exist.
-	if _, err := api.store.GetFilter(ctx, fID); err != nil {
-		status := statusCode(err)
-		if dperrors.NotFound(err) {
-			status = http.StatusBadRequest
-		}
-
-		api.respond.Error(
-			ctx,
-			w,
-			status,
-			Error{
-				err:     errors.Wrap(err, "failed to get filter from store"),
-				message: "failed to get filter",
-				logData: logData,
-			},
-		)
-		return
-	}
-
-	filterDim, err := api.store.GetFilterDimension(ctx, fID, dimName)
-	if err != nil {
-		api.respond.Error(
-			ctx,
-			w,
-			statusCode(err),
-			Error{
-				err:     errors.Wrap(err, "failed to get filter dimension from store"),
-				message: "failed to get filter dimension",
-				logData: logData,
-			},
-		)
-		return
-	}
-
-	var resp getFilterDimensionResponse
-	resp.dimensionItem.fromDimension(filterDim, api.cfg.FilterAPIURL, fID)
-	resp.IsAreaType = filterDim.IsAreaType
-
-	api.respond.JSON(ctx, w, http.StatusOK, resp)
-}
-
-func (api *API) isValidDatasetDimensions(w http.ResponseWriter, ctx context.Context, logData log.Data, v dataset.Version, d []model.Dimension, pt string) bool {
-	if v.State != published && !dprequest.IsCallerPresent(ctx) {
-		api.respond.Error(
-			ctx,
-			w,
-			http.StatusNotFound,
-			Error{
-				err:     errors.New("unauthenticated request on unpublished dataset"),
-				message: "dataset not found",
-				logData: logData,
-			},
-		)
-		return false
-	}
-
+func (api *API) isValidDatasetDimensions(ctx context.Context, v dataset.Version, d []model.Dimension, pType string) error {
 	dimIDs, err := api.validateDimensions(d, v.Dimensions)
 	if err != nil {
-		api.respond.Error(
-			ctx,
-			w,
-			http.StatusBadRequest,
-			Error{
-				err:     errors.Wrap(err, "failed to validate request dimensions"),
-				logData: logData,
-			},
-		)
-		return false
+		return Error{
+			err:      errors.Wrap(err, "failed to validate request dimensions"),
+			notFound: true,
+		}
 	}
 
-	// Validate dimension options by performing Cantabular query with selections,
-	// skip this check if requesting all options
-	if err := api.validateDimensionOptions(ctx, d, dimIDs, pt); err != nil {
-		api.respond.Error(
-			ctx,
-			w,
-			statusCode(err),
-			Error{
-				err:     errors.Wrap(err, "failed to validate dimension options"),
-				logData: logData,
-			},
-		)
-		return false
+	if err := api.validateDimensionOptions(ctx, d, dimIDs, pType); err != nil {
+		return errors.Wrap(err, "failed to validate dimension options")
 	}
 
-	return true
+	return nil
 }
 
 // getCantabularDimension checks that dimension exists in Cantabular by searching for it.
@@ -753,6 +392,8 @@ func (api *API) validateDimensions(filterDims []model.Dimension, dims []dataset.
 	return dimensions, nil
 }
 
+// validateDimensionOptions by performing Cantabular query with selections,
+// will be skipped if requesting all options
 func (api *API) validateDimensionOptions(ctx context.Context, filterDimensions []model.Dimension, dimIDs map[string]string, populationType string) error {
 	dReq := cantabular.GetDimensionOptionsRequest{
 		Dataset: populationType,


### PR DESCRIPTION
### What

Moved filter/{id}/dimensions based handlers to their own file filter_dimensions.go, created blank filter_dimension_options.go in preperation for upcoming PRs.

This to save extra clutter in the forthcoming PRs with actual changes.

Also refactored usage of `isValidDatasetDImension` as it was misleading and obscuring the codepath while not saving much/any lines of code.

No functionality should have changed, no tests updated.

### How to review

Check changes make sense, tests still pass

### Who can review

Anyone