### PR TITLE
5772 - Add FilterByParent to the Dimension model

### DIFF
--- a/api/filters.go
+++ b/api/filters.go
@@ -403,7 +403,7 @@ func (api *API) validateDimensionOptions(ctx context.Context, filterDimensions [
 			dReq.DimensionNames = append(dReq.DimensionNames, dimIDs[d.Name])
 			dReq.Filters = append(dReq.Filters, cantabular.Filter{
 				Codes:    d.Options,
-				Variable: dimIDs[d.Name],
+				Variable: dimIDs[getFilterVariable(dimIDs, d)],
 			})
 		}
 	}
@@ -428,6 +428,14 @@ func (api *API) validateDimensionOptions(ctx context.Context, filterDimensions [
 	}
 
 	return nil
+}
+
+func getFilterVariable(dimIDs map[string]string, d model.Dimension) string {
+	fVariable := dimIDs[d.Name]
+	if len(d.FilterByParent) != 0 {
+		fVariable = d.FilterByParent
+	}
+	return fVariable
 }
 
 // hydrateDimensions adds additional data (id/label) to a model.Dimension, using values provided by the dataset.

--- a/api/filters_test.go
+++ b/api/filters_test.go
@@ -13,6 +13,36 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
+func Test_getFilterVariable(t *testing.T) {
+	Convey("Given an array of dimension IDs exists", t, func() {
+		dimIDs := map[string]string{"city": "city"}
+
+		Convey("When I have a dimension with no FilterByParent", func() {
+			d := model.Dimension{
+				Name:           "city",
+				FilterByParent: "",
+			}
+
+			Convey("Then the 'city' should be returned as the filter variable", func() {
+				got := getFilterVariable(dimIDs, d)
+				So(got, ShouldResemble, "city")
+			})
+		})
+
+		Convey("When I have a dimension with a FilterByParent", func() {
+			d := model.Dimension{
+				Name:           "city",
+				FilterByParent: "region",
+			}
+
+			Convey("Then 'region' should be returned as the filter variable", func() {
+				got := getFilterVariable(dimIDs, d)
+				So(got, ShouldResemble, "region")
+			})
+		})
+	})
+}
+
 func TestValidateDimensions(t *testing.T) {
 	var api API
 

--- a/features/create_filter.authorized.feature
+++ b/features/create_filter.authorized.feature
@@ -85,7 +85,8 @@ Feature: Filters Private Endpoints Enabled
             "London",
             "Swansea"
           ],
-          "is_area_type": true
+          "is_area_type": true,
+          "filter_by_parent": "country"
         }
       ]
     }
@@ -138,7 +139,7 @@ Feature: Filters Private Endpoints Enabled
           "href": ":27100/filters/94310d8d-72d6-492a-bc30-27584627edb1/dimensions"
         }
       },
-      "etag":        "e70f6470a26c2379b591b34e47e50321879abcbc",
+      "etag":        "23a9465237f56092a95275d5d80ac79f31eff349",
       "instance_id": "c733977d-a2ca-4596-9cb1-08a6e724858b",
       "dimensions": [
         {
@@ -161,7 +162,8 @@ Feature: Filters Private Endpoints Enabled
             "London",
             "Swansea"
           ],
-          "is_area_type":  true
+          "is_area_type":  true,
+          "filter_by_parent": "country"
         }
       ],
       "dataset": {

--- a/model/filter.go
+++ b/model/filter.go
@@ -56,11 +56,12 @@ type Event struct {
 }
 
 type Dimension struct {
-	Name       string   `bson:"name"          json:"name"`
-	ID         string   `bson:"id"            json:"id"`
-	Label      string   `bson:"label"         json:"label"`
-	Options    []string `bson:"options"       json:"options"`
-	IsAreaType bool     `bson:"is_area_type"  json:"is_area_type"`
+	Name           string   `bson:"name"          json:"name"`
+	ID             string   `bson:"id"            json:"id"`
+	Label          string   `bson:"label"         json:"label"`
+	Options        []string `bson:"options"       json:"options"`
+	IsAreaType     bool     `bson:"is_area_type"  json:"is_area_type"`
+	FilterByParent string   `bson:"filter_by_parent,omitempty" json:"filter_by_parent,omitempty"`
 }
 
 type Dataset struct {


### PR DESCRIPTION
### What

[5772 - Add FilterByParent to the Dimension model](https://github.com/ONSdigital/dp-cantabular-filter-flex-api/commit/15b373510e1b22f339ad8dcbb2997f9d435e513f)

Also a small change to `validateDimensionOptions` to check if the `FilterByParent` is preseent.
If it is, use value instead of Dimension.ID for filter.Variable

Also I am syncing  `master` with `develop` 

### How to review

Sense check it and ensure tests are green

### Who can review

Any ONS developer
