### PR TITLE
Revert "temporary change to fix when IsAreaType is passes as nil from…

### DIFF
--- a/api/contract.go
+++ b/api/contract.go
@@ -45,10 +45,9 @@ func (r *createFilterRequest) Valid() error {
 			return fmt.Errorf("missing field: [dimension[%d].name]", i)
 		}
 
-		/*Temporary commit to make florence work when passing a dimension with nil IsAreaType
-		 if d.IsAreaType == nil {
+		if d.IsAreaType == nil {
 			return fmt.Errorf("missing field: [dimension[%d].is_area_type", i)
-		}*/
+		}
 
 		if len(d.ID) != 0 {
 			return fmt.Errorf("unexpected field id provided for: %s", d.Name)

--- a/features/create_filter.feature
+++ b/features/create_filter.feature
@@ -466,10 +466,10 @@ Feature: Filters Private Endpoints Not Enabled
 
     Then I should receive the following JSON response:
     """
-    {"errors":["dataset not found"]}
+    {"errors":["failed to parse request: invalid request: missing field: [dimension[0].is_area_type"]}
     """
     
-    And the HTTP status code should be "404"
+    And the HTTP status code should be "400"
 
   Scenario: Creating a new invalid request
     When I POST "/filters"


### PR DESCRIPTION
… florence"

This reverts commit d92f2cce23a6c667ae2f1e7315c96c8f4d92c368.

### What

Undoes the temporary commenting out of some code which was breaking existing published datasets imported incorrectly.
Dependant on https://github.com/ONSdigital/dp-dataset-api/pull/376 (do not merge first)
 
### How to review

Check changes are correct

### Who can review

Anyone