### PR TITLE
5862 Update Cantabular API Ext Healthcheck query

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ replace github.com/spf13/cobra => github.com/spf13/cobra v1.4.0
 exclude github.com/gorilla/sessions v1.2.1
 
 require (
-	github.com/ONSdigital/dp-api-clients-go/v2 v2.171.0
+	github.com/ONSdigital/dp-api-clients-go/v2 v2.181.1
 	github.com/ONSdigital/dp-authorisation v0.2.0
 	github.com/ONSdigital/dp-component-test v0.8.0
 	github.com/ONSdigital/dp-healthcheck v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -44,8 +44,8 @@ github.com/ONSdigital/dp-api-clients-go v1.34.3/go.mod h1:kX+YKuoLYLfkeLHMvQKRRy
 github.com/ONSdigital/dp-api-clients-go v1.41.1/go.mod h1:Ga1+ANjviu21NFJI9wp5NctJIdB4TJLDGbpQFl2V8Wc=
 github.com/ONSdigital/dp-api-clients-go v1.43.0 h1:0982P/YxnYXvba1RhEcFmwF3xywC4eXokWQ8YH3Mm24=
 github.com/ONSdigital/dp-api-clients-go v1.43.0/go.mod h1:V5MfINik+o3OAF985UXUoMjXIfrZe3JKYa5AhZn5jts=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.171.0 h1:m9xfcTqRzmtvpiqSGSq6+9PkGZPxSyggcolF3JIlvn0=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.171.0/go.mod h1:2IF90BHkQjNBzs3El66r0qOPFQ0kJq+zPfHUwCk5rgo=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.181.1 h1:793aKAnL2KnddDeIs3KHkxdsESi9WWD6mJSgPtn85nM=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.181.1/go.mod h1:2IF90BHkQjNBzs3El66r0qOPFQ0kJq+zPfHUwCk5rgo=
 github.com/ONSdigital/dp-authorisation v0.2.0 h1:QVjTUSR3c1swZwP7lMbvnBsh4Je9oc54eGzgwPOvHOc=
 github.com/ONSdigital/dp-authorisation v0.2.0/go.mod h1:Tg3BiohT3+bRv4vr4aid/1Rf+S3eXLUI8oHbOLFqFpQ=
 github.com/ONSdigital/dp-component-test v0.8.0 h1:bXl+doGHCyL7cFqSZz3fBqFhhrQxqc6IG7VKuhqKwN4=


### PR DESCRIPTION
### What

Currently when our services do a healthcheck against `cantabular-api-ext` an empty query is sent to check the connectivity which is throwing errors in the logs and making it difficult to debug the extended api.

The error that appears on the logs is the following:
```
t=2022-09-21T16:27:56Z ns=api-ext lvl=info ev=graphql query={} op= vars=
t=2022-09-21T16:27:56Z ns=api-ext lvl=info ev=message msg="GraphQL error: Syntax Error GraphQL request (1:1) Unexpected empty IN {}\n\n1: {}\n   ^\n"
t=2022-09-21T16:27:56Z ns=api-ext lvl=info ev=http port=8492 url="/graphql?query={}" method=GET httpStatus=200 contentType=application/json remoteAddr=172.20.0.34 authUser= nBytes=150
```

Going forward the response on the logs should be:
```
t=2022-09-21T17:06:33Z ns=api-ext lvl=info ev=graphql query={datasets{name}} op= vars=
t=2022-09-21T17:06:33Z ns=api-ext lvl=info ev=http port=8492 url="/graphql?query={datasets{name}}" method=GET httpStatus=200 contentType=application/json remoteAddr=172.20.0.1 authUser= nBytes=128
```

https://user-images.githubusercontent.com/102318/191567566-49a29562-b3d0-446e-8c7a-44b240beefcd.mp4


Resolves: [5862](https://trello.com/c/3dsfjvv9/5862-update-cantabular-api-ext-health-check-to-send-the-correct-query)

### How to review

Sense check it and ensure tests are :green_circle: 

### Who can review
Any ONS Developer

