### PR TITLE
patch: remove filter output locking

### DIFF
--- a/datastore/mongodb/filter_outputs.go
+++ b/datastore/mongodb/filter_outputs.go
@@ -85,11 +85,19 @@ func (c *Client) UpdateFilterOutput(ctx context.Context, f *model.FilterOutput) 
 
 	update := bson.M{"$set": fields}
 
-	lockID, err := col.lock(ctx, f.ID)
-	if err != nil {
-		return err
-	}
-	defer col.unlock(ctx, lockID)
+	/*
+	   The locking for now has been commented out to
+	   understand the 300 concurrent users test failures
+	   occurring as part of the platform team testing.
+	   It may be reinstated, so left in, along with all locking
+	   features in the mocks.
+	*/
+
+	// lockID, err := col.lock(ctx, f.ID)
+	// if err != nil {
+	//	return err
+	// }
+	// defer col.unlock(ctx, lockID)
 
 	rec, err := c.conn.Collection(col.name).Update(ctx, queryFilter, update)
 	if err != nil {


### PR DESCRIPTION
### What

Comment out the locking when updating filter outputs. 
This is to experiment whether the 300 concurrent user test can pass. 
Tests were left as is, because it is unclear whether this locking will stay in the future.

### How to review

run `make test` and `make test-component` to see no changes 
inspect commented code

### Who can review

team b 
