### PR TITLE
Revert "Revert "temporary change to fix when IsAreaType is passes as …

### DIFF
--- a/api/contract.go
+++ b/api/contract.go
@@ -45,9 +45,10 @@ func (r *createFilterRequest) Valid() error {
 			return fmt.Errorf("missing field: [dimension[%d].name]", i)
 		}
 
-		if d.IsAreaType == nil {
+		/*Temporary commit to make florence work when passing a dimension with nil IsAreaType
+		 if d.IsAreaType == nil {
 			return fmt.Errorf("missing field: [dimension[%d].is_area_type", i)
-		}
+		}*/
 
 		if len(d.ID) != 0 {
 			return fmt.Errorf("unexpected field id provided for: %s", d.Name)

--- a/features/create_filter.feature
+++ b/features/create_filter.feature
@@ -466,10 +466,10 @@ Feature: Filters Private Endpoints Not Enabled
 
     Then I should receive the following JSON response:
     """
-    {"errors":["failed to parse request: invalid request: missing field: [dimension[0].is_area_type"]}
+    {"errors":["dataset not found"]}
     """
     
-    And the HTTP status code should be "400"
+    And the HTTP status code should be "404"
 
   Scenario: Creating a new invalid request
     When I POST "/filters"


### PR DESCRIPTION
…nil from florence""

This reverts commit 0ee74b43176eb80f5ef87d306d3d571c6c14872f.

### What

Temporarily rolling back this commit again to allow usage of existing dataset landing pages until Florence is back online

### How to review

 Check change makes sense

### Who can review

Anyone