### PR TITLE
5895 - PUT /filters/{id}/dimensions/{name} accessible only from FE apps

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	// "net/http"
 
 	"github.com/ONSdigital/dp-cantabular-filter-flex-api/config"
 	kafka "github.com/ONSdigital/dp-kafka/v3"
@@ -64,7 +63,6 @@ func (api *API) enablePublicEndpoints() {
 	api.Router.Get("/filters/{id}/dimensions/{dimension}/options", api.getFilterDimensionOptions)
 	api.Router.Delete("/filters/{id}/dimensions/{dimension}/options", api.deleteFilterDimensionOptions)
 	api.Router.Get("/filters/{id}/dimensions/{dimension}", api.getFilterDimension)
-	api.Router.Put("/filters/{id}/dimensions/{dimension}", api.updateFilterDimension)
 	api.Router.Get("/filters/{id}/dimensions/{dimension}", api.getFilterDimension)
 	api.Router.Delete("/filters/{id}/dimensions/{dimension}", api.deleteFilterDimension)
 
@@ -85,6 +83,12 @@ func (api *API) enablePublicEndpoints() {
 			With(middleware.LogIdentity()).
 			With(permissions.Require(auth.Permissions{Read: true})).
 			Put("/filter-outputs/{id}", api.putFilterOutput)
+
+		api.Router.
+			With(checkIdentity).
+			With(middleware.LogIdentity()).
+			With(permissions.Require(auth.Permissions{Read: true})).
+			Put("/filters/{id}/dimensions/{dimension}", api.updateFilterDimension)
 	}
 }
 

--- a/api/api.go
+++ b/api/api.go
@@ -74,10 +74,9 @@ func (api *API) enablePublicEndpoints() {
 
 	api.Router.Get("/filter-outputs/{id}", api.getFilterOutput)
 
-	api.Router.Get("/datasets/{dataset_id}/editions/{edition}/versions/{version}/json", api.getDatasetJSON)
+	api.Router.Get("/datasets/{dataset_id}/editions/{edition}/versions/{version}/json", api.getDatasetJSONHandler)
 
 	if api.cfg.EnableFilterOutputs {
-
 		permissions := middleware.NewPermissions(api.cfg.ZebedeeURL, api.cfg.EnablePermissionsAuth)
 		checkIdentity := dphandlers.IdentityWithHTTPClient(api.identityClient)
 
@@ -86,7 +85,6 @@ func (api *API) enablePublicEndpoints() {
 			With(middleware.LogIdentity()).
 			With(permissions.Require(auth.Permissions{Read: true})).
 			Put("/filter-outputs/{id}", api.putFilterOutput)
-
 	}
 }
 

--- a/api/api.go
+++ b/api/api.go
@@ -74,7 +74,20 @@ func (api *API) enablePublicEndpoints() {
 
 	api.Router.Get("/filter-outputs/{id}", api.getFilterOutput)
 
-	api.Router.Get("/datasets/{dataset_id}/editions/{edition}/versions/{version}/json", api.getDatasetJSONHandler)
+	api.Router.Get("/datasets/{dataset_id}/editions/{edition}/versions/{version}/json", api.getDatasetJSON)
+
+	if api.cfg.EnableFilterOutputs {
+
+		permissions := middleware.NewPermissions(api.cfg.ZebedeeURL, api.cfg.EnablePermissionsAuth)
+		checkIdentity := dphandlers.IdentityWithHTTPClient(api.identityClient)
+
+		api.Router.
+			With(checkIdentity).
+			With(middleware.LogIdentity()).
+			With(permissions.Require(auth.Permissions{Read: true})).
+			Put("/filter-outputs/{id}", api.putFilterOutput)
+
+	}
 }
 
 func (api *API) enablePrivateEndpoints() {

--- a/config/config.go
+++ b/config/config.go
@@ -32,12 +32,9 @@ type Config struct {
 	ZebedeeURL                   string        `envconfig:"ZEBEDEE_URL"`
 	DatasetOptionsWorkers        int           `envconfig:"DATASET_OPTIONS_WORKERS"`
 	DatasetOptionsBatchSize      int           `envconfig:"DATASET_OPTIONS_BATCH_SIZE"`
-
-	EnableFilterOutputs bool `envconfig:"ENABLE_FILTER_OUTPUTS_CHECK"`
-	FilterOutputToken   bool `envconfig:"FILTER_OUTPUT_TOKEN"`
-
-	Mongo       mongo.MongoDriverConfig
-	KafkaConfig KafkaConfig
+	EnableFilterOutputs          bool          `envconfig:"ENABLE_FILTER_OUTPUTS_CHECK"`
+	Mongo                        mongo.MongoDriverConfig
+	KafkaConfig                  KafkaConfig
 }
 
 type KafkaConfig struct {
@@ -88,6 +85,7 @@ func Get() (*Config, error) {
 		ZebedeeURL:                   "http://localhost:8082",
 		DatasetOptionsWorkers:        2,
 		DatasetOptionsBatchSize:      20,
+		EnableFilterOutputs:          true,
 		Mongo: mongo.MongoDriverConfig{
 			ClusterEndpoint: "localhost:27017",
 			Username:        "",

--- a/config/config.go
+++ b/config/config.go
@@ -32,8 +32,12 @@ type Config struct {
 	ZebedeeURL                   string        `envconfig:"ZEBEDEE_URL"`
 	DatasetOptionsWorkers        int           `envconfig:"DATASET_OPTIONS_WORKERS"`
 	DatasetOptionsBatchSize      int           `envconfig:"DATASET_OPTIONS_BATCH_SIZE"`
-	Mongo                        mongo.MongoDriverConfig
-	KafkaConfig                  KafkaConfig
+
+	EnableFilterOutputs bool `envconfig:"ENABLE_FILTER_OUTPUTS_CHECK"`
+	FilterOutputToken   bool `envconfig:"FILTER_OUTPUT_TOKEN"`
+
+	Mongo       mongo.MongoDriverConfig
+	KafkaConfig KafkaConfig
 }
 
 type KafkaConfig struct {

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/eapache/queue v1.1.0 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/go-avro/avro v0.0.0-20171219232920-444163702c11 // indirect
-	github.com/go-test/deep v1.0.3 // indirect
+	github.com/go-test/deep v1.0.8 // indirect
 	github.com/gobwas/httphead v0.1.0 // indirect
 	github.com/gobwas/pool v0.2.1 // indirect
 	github.com/gobwas/ws v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -161,8 +161,8 @@ github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-test/deep v1.0.1/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
-github.com/go-test/deep v1.0.3 h1:ZrJSEWsXzPOxaZnFteGEfooLba+ju3FYIbOrS+rQd68=
-github.com/go-test/deep v1.0.3/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
+github.com/go-test/deep v1.0.8 h1:TDsG77qcSprGbC6vTN8OuXp5g+J+b5Pcguhf7Zt61VM=
+github.com/go-test/deep v1.0.8/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/gobwas/httphead v0.1.0 h1:exrUm0f4YX0L7EBwZHuCF4GDp8aJfVeBrlLQrs6NqWU=
 github.com/gobwas/httphead v0.1.0/go.mod h1:O/RXo79gxV8G+RqlR/otEwx4Q36zl9rqC5u12GKvMCM=
 github.com/gobwas/pool v0.2.1 h1:xfeeEhW7pwmX8nuLVlqbzVc7udMDrwetjEv+TZIz1og=


### PR DESCRIPTION
### What

 * The `PUT /filters/{filter-id}/dimensions/{dimension-name}` should  now only be accessible by the web frontend services.
 * Our API users should no longer be able to access this endpoint.
 * This endpoint should be made private, with a similar solution  to what we have implemented for the `PUT /filter-outputs` endpoint  to ensure only authenticated services can access the functionality.

**Note:** 
 * This PR has been branched from https://github.com/ONSdigital/dp-filter-api/pull/274. 
 * Once the above is merged, rebase `develop` into this branch:
    * `git rebase develop`
    * `git push origin +feature/5895-put-filters-name`

**Depends on:** https://github.com/ONSdigital/dp-filter-api/pull/276

**Resolves: [5895](https://trello.com/c/hsYufI1J/5895-make-the-put-filters-filter-id-dimensions-dimension-name-only-accessible-from-the-website)**


### How to review

Sense check it and ensure tests are :green_circle:

### Who can review

Any ONS developer
