### PR TITLE
Added put filter outputs as public endpoint

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -73,19 +73,9 @@ func (api *API) enablePublicEndpoints() {
 	api.Router.Delete("/filters/{id}/dimensions/{dimension}/options/{option}", api.deleteFilterDimensionOption)
 
 	api.Router.Get("/filter-outputs/{id}", api.getFilterOutput)
+	api.Router.Put("/filter-outputs/{id}", api.putFilterOutput)
 
 	api.Router.Get("/datasets/{dataset_id}/editions/{edition}/versions/{version}/json", api.getDatasetJSONHandler)
-
-	if api.cfg.EnableFilterOutputs {
-		//permissions := middleware.NewPermissions(api.cfg.ZebedeeURL, api.cfg.EnablePermissionsAuth)
-		//checkIdentity := dphandlers.IdentityWithHTTPClient(api.identityClient)
-
-		api.Router.
-			//With(checkIdentity).
-			//With(middleware.LogIdentity()).
-			//With(permissions.Require(auth.Permissions{Read: true})).
-			Put("/filter-outputs/{id}", api.putFilterOutput)
-	}
 }
 
 func (api *API) enablePrivateEndpoints() {

--- a/config/config.go
+++ b/config/config.go
@@ -32,7 +32,6 @@ type Config struct {
 	ZebedeeURL                   string        `envconfig:"ZEBEDEE_URL"`
 	DatasetOptionsWorkers        int           `envconfig:"DATASET_OPTIONS_WORKERS"`
 	DatasetOptionsBatchSize      int           `envconfig:"DATASET_OPTIONS_BATCH_SIZE"`
-	EnableFilterOutputs          bool          `envconfig:"ENABLE_FILTER_OUTPUTS_CHECK"`
 	Mongo                        mongo.MongoDriverConfig
 	KafkaConfig                  KafkaConfig
 }
@@ -85,7 +84,6 @@ func Get() (*Config, error) {
 		ZebedeeURL:                   "http://localhost:8082",
 		DatasetOptionsWorkers:        2,
 		DatasetOptionsBatchSize:      20,
-		EnableFilterOutputs:          true,
 		Mongo: mongo.MongoDriverConfig{
 			ClusterEndpoint: "localhost:27017",
 			Username:        "",


### PR DESCRIPTION
### What

Endpoint /filter-outputs/{id} is now exposed as public endpoint as this is used in web filter flex journey to generate the downloads. 

### How to review

All tests are :green_circle:

### Who can review

Anyone
