### PR TITLE
upgrade dp-api-clients-go to 2.228.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ replace github.com/spf13/cobra => github.com/spf13/cobra v1.4.0
 exclude github.com/gorilla/sessions v1.2.1
 
 require (
-	github.com/ONSdigital/dp-api-clients-go/v2 v2.226.0
+	github.com/ONSdigital/dp-api-clients-go/v2 v2.228.0
 	github.com/ONSdigital/dp-authorisation v0.2.0
 	github.com/ONSdigital/dp-component-test v0.9.0
 	github.com/ONSdigital/dp-healthcheck v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/ONSdigital/dp-api-clients-go v1.43.0 h1:0982P/YxnYXvba1RhEcFmwF3xywC4
 github.com/ONSdigital/dp-api-clients-go v1.43.0/go.mod h1:V5MfINik+o3OAF985UXUoMjXIfrZe3JKYa5AhZn5jts=
 github.com/ONSdigital/dp-api-clients-go/v2 v2.226.0 h1:3XKOD24BsJUfzV75TDgOhPv0cdRy6DKCvqvEd9GEDeQ=
 github.com/ONSdigital/dp-api-clients-go/v2 v2.226.0/go.mod h1:8r9bmqlBNWMQdf1jjjEQUZ26kOaVanxSthAfBM245os=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.228.0 h1:f6BND+3paPonDj9Wij/WdcTvnxPialp2Cq8QWIIDln4=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.228.0/go.mod h1:8r9bmqlBNWMQdf1jjjEQUZ26kOaVanxSthAfBM245os=
 github.com/ONSdigital/dp-authorisation v0.2.0 h1:QVjTUSR3c1swZwP7lMbvnBsh4Je9oc54eGzgwPOvHOc=
 github.com/ONSdigital/dp-authorisation v0.2.0/go.mod h1:Tg3BiohT3+bRv4vr4aid/1Rf+S3eXLUI8oHbOLFqFpQ=
 github.com/ONSdigital/dp-component-test v0.9.0 h1:DfSvL1CKrZ4Jm/WqNLw27DtOcn2fmPI6KNx9zaFYgCo=


### PR DESCRIPTION
### What

Upgrade `dp-api-clients-go` version to `v2.228.0`

### How to review

Confirm we are using `v2.228.0` of `dp-api-clients-go`

### Who can review

Anyone
