### PR TITLE
fix for quality statement/url

### DIFF
--- a/api/validation.go
+++ b/api/validation.go
@@ -105,8 +105,8 @@ func (api *API) HydrateMultivariateDimensionsPOST(dimensions []model.Dimension, 
 			Options:               dim.Options,
 			IsAreaType:            dim.IsAreaType,
 			FilterByParent:        dim.FilterByParent,
-			QualityStatementText:  dim.QualityStatementText,
-			QualitySummaryURL:     dim.QualitySummaryURL,
+			QualityStatementText:  node.QualityStatementText,
+			QualitySummaryURL:     node.QualitySummaryURL,
 		})
 	}
 	return hydratedDimensions, nil


### PR DESCRIPTION
### What

Fix for QualityStatementText and QualityStatementURL not showing in filtered dimension response

Should be `node.QualityStatementText` and `node.QualitySummaryURL` instead of `dim`, as `dim` is just the dimensions that we're passing into that function, rather than what's being returned from the `getCantabularDimension` function

### How to review

Changes make sense, tests pass

### Who can review

Anyone
