### PR TITLE
Add temporary debugging code to dump http headers on specific requests

### DIFF
--- a/api/dataset.go
+++ b/api/dataset.go
@@ -41,7 +41,7 @@ func (api *API) getDatasetJSONHandler(w http.ResponseWriter, r *http.Request) {
 	// This entire section is skipped when not enabled so should not impact prod if accidentally deployed
 	// Can be removed if in doubt along with global var `debugHeaders`
 	if debugHeaders {
-		//Only output headers for requests supplying the valid debugging key
+		// Only output headers for requests supplying the valid debugging key
 		q := r.URL.Query()
 		clientKey, ok := q["debug_key"]
 		if ok && clientKey[0] == os.Getenv("ROUTER_DEBUG_KEY") {

--- a/go.mod
+++ b/go.mod
@@ -116,7 +116,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.21.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	golang.org/x/crypto v0.16.0 // indirect
+	golang.org/x/crypto v0.17.0 // indirect
 	golang.org/x/net v0.18.0 // indirect
 	golang.org/x/sync v0.3.0 // indirect
 	golang.org/x/sys v0.15.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1113,6 +1113,8 @@ golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0
 golang.org/x/crypto v0.6.0/go.mod h1:OFC/31mSvZgRz0V1QTNCzfAI1aIRzbiufJtkMIlEp58=
 golang.org/x/crypto v0.16.0 h1:mMMrFzRSCF0GvB7Ne27XVtVAaXLrPmgPC7/v0tkwHaY=
 golang.org/x/crypto v0.16.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
+golang.org/x/crypto v0.17.0 h1:r8bRNjWL3GshPW3gkd+RpvzWrZAwPS49OmTGZ/uhM4k=
+golang.org/x/crypto v0.17.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20180807140117-3d87b88a115f/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=


### PR DESCRIPTION
### What

Add temporary debugging code to dump http headers on specific requests

This will enable us to add a url parameter on specific requests and get a dump of the request's internal http request headers in the logs. For safety reasons, only the values of configured headers will be dumped out in order to prevent logging of sensitive values, eg. auth tokens. Also this functionality is only enabled when the debug key is set so causes no performance hit if unintentionally deployed to prod. 

This code is only intended to be deployed as far as staging so it can be tested with CloudFlare. 

To use, the env vars will be configured in vault…
- `ROUTER_DEBUG_KEY` = some value only know to us to stop anyone public using it (debugging disabled if blank)
- `ROUTER_DEBUG_HEADERS` = comma-separated list of headers whose values are alowed to be dumped to the logs (eg. `"X-Forwarded-For,Accept,Accept-Encoding"`

Requests can be made to trigger the debugging by adding the URL parameter `debug_key=some_value`.

NB. Also bumps adependency version that causes an audit failure

### How to review

Ensure the code does as described, especially that it will be disabled by default and only apply to a very limited and specific subset of requests.

Ensure tests pass.

### Who can review

Anyone but me.