### PR TITLE
Fix for oom kill

### DIFF
--- a/api/dataset.go
+++ b/api/dataset.go
@@ -56,16 +56,18 @@ func (api *API) getDatasetJSONHandler(w http.ResponseWriter, r *http.Request) {
 
 	resp, err := api.getDatasetJSON(ctx, r, params)
 
-	if resp.TotalObservations > api.cfg.MaxRowsReturned {
-		api.respond.Error(
-			ctx,
-			w,
-			403,
-			Error{
-				message: "Too many rows returned, please refine your query by requesting specific areas or reducing the number of categories returned.  For further information please visit https://developer.ons.gov.uk/createyourowndataset/",
-			},
-		)
-		return
+	if resp != nil {
+		if resp.TotalObservations > api.cfg.MaxRowsReturned {
+			api.respond.Error(
+				ctx,
+				w,
+				403,
+				Error{
+					message: "Too many rows returned, please refine your query by requesting specific areas or reducing the number of categories returned.  For further information please visit https://developer.ons.gov.uk/createyourowndataset/",
+				},
+			)
+			return
+		}
 	}
 
 	if err != nil {

--- a/api/dataset.go
+++ b/api/dataset.go
@@ -55,6 +55,19 @@ func (api *API) getDatasetJSONHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp, err := api.getDatasetJSON(ctx, r, params)
+
+	if resp.TotalObservations > api.cfg.MaxRowsReturned {
+		api.respond.Error(
+			ctx,
+			w,
+			403,
+			Error{
+				message: "Too many rows returned, please refine your query by requesting specific areas or reducing the number of categories returned.  For further information please visit https://developer.ons.gov.uk/createyourowndataset/",
+			},
+		)
+		return
+	}
+
 	if err != nil {
 		api.respond.Error(
 			ctx,

--- a/features/get-dataset-observations.feature
+++ b/features/get-dataset-observations.feature
@@ -580,6 +580,8 @@ Feature: Get Dataset Observations
     }
     """
 
+    And the maximum rows allowed to be returned is 100
+
   Scenario: Get the dataset observations
     Given Cantabular returns this static dataset for the given request:
     """


### PR DESCRIPTION
### What

Added a check on the /json endpoint to reduce the number of results returned to protect dp-api-router.  The /census-observations endpoint already works in the same way.  This should not affect user experience as users requesting the large datasets are currently receiving 50x status code responses as the api-router cannot process the response.

### How to review

Ensure the tests pass and the changes make sense.

### Who can review

Anyone
